### PR TITLE
Fix SGX private key reuse and enable SGX's EDMM feature back

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,22 +1,48 @@
 #!/usr/bin/env bash
-set -ex
 
-RAIKO_CONFIG_DIR_PATH="/root/.config/raiko/config"
-RAIKO_INPUT_MANIFEST_FILENAME="raiko-guest.manifest"
-RAIKO_OUTPUT_MANIFEST_FILENAME="raiko-guest.manifest.sgx"
-RAIKO_SIGNED_MANIFEST_FILENAME="raiko-guest.sig"
-SGX_DIR_PATH="/opt/raiko/guests/sgx"
+set -xeo pipefail
+
+GRAMINE_PRIV_KEY="$HOME/.config/gramine/enclave-key.pem"
+RAIKO_DOCKER_VOLUME_PATH="/root/.config/raiko"
+RAIKO_DOCKER_VOLUME_CONFIG_PATH="$RAIKO_DOCKER_VOLUME_PATH/config"
+RAIKO_DOCKER_VOLUME_SECRETS_PATH="$RAIKO_DOCKER_VOLUME_PATH/secrets"
+RAIKO_DOCKER_VOLUME_PRIV_KEY_PATH="$RAIKO_DOCKER_VOLUME_SECRETS_PATH/priv.key"
+RAIKO_GUEST_APP_DIR="/opt/raiko/guests/sgx"
+RAIKO_GUEST_APP_FILENAME="raiko-guest"
+RAIKO_INPUT_MANIFEST_FILENAME="$RAIKO_GUEST_APP_FILENAME.manifest"
+RAIKO_OUTPUT_MANIFEST_FILENAME="$RAIKO_GUEST_APP_FILENAME.manifest.sgx"
+RAIKO_SIGNED_MANIFEST_FILENAME="$RAIKO_GUEST_APP_FILENAME.sig"
+
+function sign_gramine_manifest() {
+    cd "$RAIKO_GUEST_APP_DIR"
+    gramine-sgx-sign --manifest "$RAIKO_INPUT_MANIFEST_FILENAME" --output "$RAIKO_OUTPUT_MANIFEST_FILENAME"
+    mkdir -p "$RAIKO_DOCKER_VOLUME_CONFIG_PATH"
+    cp "$RAIKO_OUTPUT_MANIFEST_FILENAME" "$RAIKO_SIGNED_MANIFEST_FILENAME" "$RAIKO_DOCKER_VOLUME_CONFIG_PATH"
+    cd -
+}
+
+function bootstrap() {
+    mkdir -p "$RAIKO_DOCKER_VOLUME_SECRETS_PATH"
+    cd "$RAIKO_GUEST_APP_DIR"
+    gramine-sgx "$RAIKO_GUEST_APP_FILENAME" bootstrap
+    cd -
+}
 
 /restart_aesm.sh
 
 if [[ $# -eq 1 && $1 == "--init" ]]; then
-    cd "$SGX_DIR_PATH"
-    gramine-sgx-gen-private-key
-    gramine-sgx-sign --manifest "$RAIKO_INPUT_MANIFEST_FILENAME" --output "$RAIKO_OUTPUT_MANIFEST_FILENAME"
-    cp "$RAIKO_OUTPUT_MANIFEST_FILENAME" "$RAIKO_SIGNED_MANIFEST_FILENAME" "$RAIKO_CONFIG_DIR_PATH"
-    gramine-sgx ./raiko-guest bootstrap
+    if [[ ! -f "$GRAMINE_PRIV_KEY" ]]; then
+        gramine-sgx-gen-private-key
+    fi
+    sign_gramine_manifest
+    bootstrap
 else
-    ln -sf "$RAIKO_CONFIG_DIR_PATH/$RAIKO_OUTPUT_MANIFEST_FILENAME" "$SGX_DIR_PATH"
-    ln -sf "$RAIKO_CONFIG_DIR_PATH/$RAIKO_SIGNED_MANIFEST_FILENAME" "$SGX_DIR_PATH"
+    if [[ ! -f "$RAIKO_DOCKER_VOLUME_PRIV_KEY_PATH" ]]; then
+        echo "Application was not bootstrapped. "\
+             "$RAIKO_DOCKER_VOLUME_PRIV_KEY_PATH is missing. Bootstrap it first." >&2
+        exit 1
+    fi
+
+    sign_gramine_manifest
     /opt/raiko/bin/raiko-host "$@"
 fi

--- a/raiko-guest/config/raiko-guest.manifest.template
+++ b/raiko-guest/config/raiko-guest.manifest.template
@@ -15,13 +15,13 @@ fs.mounts = [
   { path = "/usr/lib/ssl/certs/", uri = "file:/usr/lib/ssl/certs/" },
   { path = "/tmp", uri = "file:/tmp" },
   { path = "/root/.config/raiko/config", uri = "file:/root/.config/raiko/config" },
-  { path = "/root/.config/raiko/secrets", uri = "file:{{ '/root/.config/raiko/secrets' }}", type = "encrypted", key_name = "_sgx_mrsigner" },
+  { path = "/root/.config/raiko/secrets", uri = "file:/root/.config/raiko/secrets", type = "encrypted", key_name = "_sgx_mrsigner" },
 ]
 sys.insecure__allow_eventfd = true
 loader.insecure__use_cmdline_argv = true
 
 sgx.debug = false
-sgx.edmm_enable = false
+sgx.edmm_enable = true
 
 sgx.trusted_files = [
   "file:{{ gramine.libos }}",


### PR DESCRIPTION
This commit fixes commit no. 036888b. Disabling EDMM had a serious performance impact, so we are enabling it again.