### PR TITLE
Edmm enabled

### DIFF
--- a/README_Docker.md
+++ b/README_Docker.md
@@ -65,7 +65,8 @@ Taiko doesn't provide prebuilt Docker image (yet). You need to build it yourself
    ```
    cd raiko
    ```
-   # Enable EDMM (Only SGX2)
+   ### Enable EDMM (Only SGX2)
+   You can skip this step if you don't have SGX2 support.
     1. Enable EDMM in the manifest file.
     ```
     nano ~/raiko/raiko-guest/config/raiko-guest.manifest.template

--- a/README_Docker.md
+++ b/README_Docker.md
@@ -106,6 +106,20 @@ docker compose up raiko -d
 
 Start the Raiko daemon. Skip `-d` (which stands for _daemon_) to run in the foreground instead.
 
+### Enable EDMM (Only SGX2)
+
+1. Enable EDMM in the manifest file.
+
+    ```
+    nano ~/raiko/raiko-guest/config/raiko-guest.manifest.template
+    ```
+
+1. Add the environment variable in the `docker-compose.yml` file
+
+    ```
+    nano ~/raiko/docker/docker-compose.yml
+    ```
+
 ### Test Raiko
 
 Now, once you have Raiko up and running, you can test it to make sure it is serving requests as expected.

--- a/README_Docker.md
+++ b/README_Docker.md
@@ -63,11 +63,20 @@ Taiko doesn't provide prebuilt Docker image (yet). You need to build it yourself
    ```
 1. Change active directory:
    ```
-   cd raiko/docker
+   cd raiko
    ```
+   # Enable EDMM (Only SGX2)
+    1. Enable EDMM in the manifest file.
+    ```
+    nano ~/raiko/raiko-guest/config/raiko-guest.manifest.template
+    ```
+    1. Add the environment variable in the `docker-compose.yml` file
+    ```
+    nano ~/raiko/docker/docker-compose.yml
+    ```
 1. Build the image:
    ```
-   docker compose build
+   docker build -t raiko:latest .
    ```
 1. That's it! You should now be able to find the `raiko:latest` in the list of all Docker images:
    ```
@@ -105,20 +114,6 @@ docker compose up raiko -d
 ```
 
 Start the Raiko daemon. Skip `-d` (which stands for _daemon_) to run in the foreground instead.
-
-### Enable EDMM (Only SGX2)
-
-1. Enable EDMM in the manifest file.
-
-    ```
-    nano ~/raiko/raiko-guest/config/raiko-guest.manifest.template
-    ```
-
-1. Add the environment variable in the `docker-compose.yml` file
-
-    ```
-    nano ~/raiko/docker/docker-compose.yml
-    ```
 
 ### Test Raiko
 

--- a/README_Docker.md
+++ b/README_Docker.md
@@ -70,11 +70,11 @@ Taiko doesn't provide prebuilt Docker image (yet). You need to build it yourself
    
    Enable EDMM in the manifest file:
     ```
-    nano ~/raiko/raiko-guest/config/raiko-guest.manifest.template
+    nano raiko-guest/config/raiko-guest.manifest.template
     ```
    Add the environment variable in the `docker-compose.yml` file:
     ```
-    nano ~/raiko/docker/docker-compose.yml
+    nano docker/docker-compose.yml
     ```
 1. Build the image:
    ```

--- a/README_Docker.md
+++ b/README_Docker.md
@@ -68,11 +68,11 @@ Taiko doesn't provide prebuilt Docker image (yet). You need to build it yourself
    ### Enable EDMM (Only SGX2)
    You can skip this step if you don't have SGX2 support.
    
-   Enable EDMM in the manifest file.
+   Enable EDMM in the manifest file:
     ```
     nano ~/raiko/raiko-guest/config/raiko-guest.manifest.template
     ```
-   Add the environment variable in the `docker-compose.yml` file
+   Add the environment variable in the `docker-compose.yml` file:
     ```
     nano ~/raiko/docker/docker-compose.yml
     ```

--- a/README_Docker.md
+++ b/README_Docker.md
@@ -88,6 +88,9 @@ Taiko doesn't provide prebuilt Docker image (yet). You need to build it yourself
 ## Running Docker container
 
 After successfully building Docker image, you are now able to bootstrap and run Raiko as a daemon.
+   ```
+   cd docker
+   ```
 
 ### Raiko bootstrapping
 

--- a/README_Docker.md
+++ b/README_Docker.md
@@ -67,11 +67,12 @@ Taiko doesn't provide prebuilt Docker image (yet). You need to build it yourself
    ```
    ### Enable EDMM (Only SGX2)
    You can skip this step if you don't have SGX2 support.
-    1. Enable EDMM in the manifest file.
+   
+   Enable EDMM in the manifest file.
     ```
     nano ~/raiko/raiko-guest/config/raiko-guest.manifest.template
     ```
-    1. Add the environment variable in the `docker-compose.yml` file
+   Add the environment variable in the `docker-compose.yml` file
     ```
     nano ~/raiko/docker/docker-compose.yml
     ```

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -3,8 +3,8 @@ services:
   raiko:
     image: raiko:latest
     container_name: raiko
-    environment:
-    - EDMM=1
+#    environment:
+#   - EDMM=1
     command: --config-path=/etc/raiko/config.toml
     devices:
       - "/dev/sgx_enclave:/dev/sgx_enclave"

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,8 +1,10 @@
 version: "3.9"
 services:
   raiko:
-    image: gcr.io/evmchain/raiko:latest
+    image: raiko:latest
     container_name: raiko
+    environment:
+    - EDMM=1
     command: --config-path=/etc/raiko/config.toml
     devices:
       - "/dev/sgx_enclave:/dev/sgx_enclave"

--- a/raiko-guest/config/raiko-guest.manifest.template
+++ b/raiko-guest/config/raiko-guest.manifest.template
@@ -22,7 +22,8 @@ sys.insecure__allow_eventfd = true
 loader.insecure__use_cmdline_argv = true
 
 sgx.debug = false
-# To enable EDMM, set 'sgx.edmm_enable = true' and uncomment or add to this file 'loader.env.EDMM = "1"'.
+# To enable EDMM, set 'sgx.edmm_enable = true' and uncomment or add to this file 'loader.env.EDMM = "1"'
+# You also need to change your docker-compose.yml
 sgx.edmm_enable = false
 
 sgx.trusted_files = [

--- a/raiko-guest/config/raiko-guest.manifest.template
+++ b/raiko-guest/config/raiko-guest.manifest.template
@@ -7,6 +7,7 @@ loader.log_level = "{{ log_level }}"
 loader.env.HOME = "/root"
 loader.env.LD_LIBRARY_PATH = "/lib:{{ arch_libdir }}"
 loader.env.RUST_LOG = "info"
+loader.env.EDMM = "1"
 
 fs.mounts = [
   { path = "/lib", uri = "file:{{ gramine.runtimedir() }}" },
@@ -21,7 +22,7 @@ sys.insecure__allow_eventfd = true
 loader.insecure__use_cmdline_argv = true
 
 sgx.debug = false
-sgx.edmm_enable = {{ 'true' if env.get('EDMM', '1') == '1' else 'false' }}
+sgx.edmm_enable = true
 
 sgx.trusted_files = [
   "file:{{ gramine.libos }}",
@@ -32,7 +33,7 @@ sgx.trusted_files = [
   "file:{{ arch_libdir }}/libcrypto.so.3",
   "file:/usr/lib/ssl/certs/",
 ]
-sgx.max_threads = 16
+sgx.max_threads = 32
 sys.enable_extra_runtime_domain_names_conf = true
 sgx.remote_attestation = "dcap"
 

--- a/raiko-guest/config/raiko-guest.manifest.template
+++ b/raiko-guest/config/raiko-guest.manifest.template
@@ -7,7 +7,7 @@ loader.log_level = "{{ log_level }}"
 loader.env.HOME = "/root"
 loader.env.LD_LIBRARY_PATH = "/lib:{{ arch_libdir }}"
 loader.env.RUST_LOG = "info"
-loader.env.EDMM = "1"
+# loader.env.EDMM = "1"
 
 fs.mounts = [
   { path = "/lib", uri = "file:{{ gramine.runtimedir() }}" },
@@ -22,7 +22,8 @@ sys.insecure__allow_eventfd = true
 loader.insecure__use_cmdline_argv = true
 
 sgx.debug = false
-sgx.edmm_enable = true
+# To enable EDMM, set 'sgx.edmm_enable = true' and uncomment or add to this file 'loader.env.EDMM = "1"'.
+sgx.edmm_enable = false
 
 sgx.trusted_files = [
   "file:{{ gramine.libos }}",

--- a/raiko-guest/config/raiko-guest.manifest.template
+++ b/raiko-guest/config/raiko-guest.manifest.template
@@ -35,7 +35,7 @@ sgx.trusted_files = [
   "file:{{ arch_libdir }}/libcrypto.so.3",
   "file:/usr/lib/ssl/certs/",
 ]
-sgx.max_threads = 32
+sgx.max_threads = 16
 sys.enable_extra_runtime_domain_names_conf = true
 sgx.remote_attestation = "dcap"
 


### PR DESCRIPTION
The parameter `sgx.edmm_enable` in the manifest file does not work correctly, I set it directly to true:
`sgx.edmm_enable = {{ 'true' if env.get('EDMM', '1') == '1' else 'false' }}` to `sgx.edmm_enable = true`
and now it works perfectly.

The EDMM environment variable has also been added to the docker-compose.yml file.

![1](https://github.com/taikoxyz/raiko/assets/119992979/45ece125-5a79-4073-a105-e0e89251fc9f)
![5](https://github.com/taikoxyz/raiko/assets/119992979/07fc1fa1-8926-4342-9428-858d46e052ac)

@m514650 on Discord also helped me with this.
https://discord.com/channels/984015101017346058/1152772683054981300/1202735614538162248

I have commented on the changes, clarifying what must be done to enable EDMM and I have set the value false to `sgx.edmm_enable` to avoid conflicts.

I have added the content to the README and I have also changed some things so that the guide works correctly.

I hope this helps you.
Thanks for all your effort!