### PR TITLE
hotfix: support eip4844 transaction(type3)

### DIFF
--- a/lib/src/execution/ethereum.rs
+++ b/lib/src/execution/ethereum.rs
@@ -293,6 +293,22 @@ pub fn fill_eth_tx_env(tx_env: &mut TxEnv, essence: &EthereumTxEssence, caller: 
             tx_env.nonce = Some(tx.nonce);
             tx_env.access_list = tx.access_list.clone().into();
         }
+        EthereumTxEssence::Eip4844(tx) => {
+            tx_env.caller = caller;
+            tx_env.gas_limit = tx.gas_limit.try_into().unwrap();
+            tx_env.gas_price = tx.max_fee_per_gas;
+            tx_env.gas_priority_fee = Some(tx.max_priority_fee_per_gas);
+            tx_env.transact_to = if let TransactionKind::Call(to_addr) = tx.to {
+                TransactTo::Call(to_addr)
+            } else {
+                TransactTo::create()
+            };
+            tx_env.value = tx.value;
+            tx_env.data = tx.data.clone();
+            tx_env.chain_id = Some(tx.chain_id);
+            tx_env.nonce = Some(tx.nonce);
+            tx_env.access_list = tx.access_list.clone().into();
+        }
     };
 }
 

--- a/lib/src/taiko/execute.rs
+++ b/lib/src/taiko/execute.rs
@@ -364,6 +364,22 @@ pub fn fill_eth_tx_env(
             tx_env.nonce = Some(tx.nonce);
             tx_env.access_list = tx.access_list.clone().into();
         }
+        EthereumTxEssence::Eip4844(tx) => {
+            tx_env.caller = caller;
+            tx_env.gas_limit = tx.gas_limit.try_into().unwrap();
+            tx_env.gas_price = tx.max_fee_per_gas;
+            tx_env.gas_priority_fee = Some(tx.max_priority_fee_per_gas);
+            tx_env.transact_to = if let TransactionKind::Call(to_addr) = tx.to {
+                TransactTo::Call(to_addr)
+            } else {
+                TransactTo::create()
+            };
+            tx_env.value = tx.value;
+            tx_env.data = tx.data.clone();
+            tx_env.chain_id = Some(tx.chain_id);
+            tx_env.nonce = Some(tx.nonce);
+            tx_env.access_list = tx.access_list.clone().into();
+        }
     };
 }
 

--- a/primitives/src/ethers.rs
+++ b/primitives/src/ethers.rs
@@ -30,7 +30,8 @@ use crate::{
     signature::TxSignature,
     transactions::{
         ethereum::{
-            EthereumTxEssence, TransactionKind, TxEssenceEip1559, TxEssenceEip2930, TxEssenceLegacy,
+            EthereumTxEssence, TransactionKind, TxEssenceEip1559, TxEssenceEip2930,
+            TxEssenceEip4844, TxEssenceLegacy,
         },
         optimism::{OptimismTxEssence, TxEssenceOptimismDeposited},
         Transaction, TxEssence,
@@ -208,6 +209,31 @@ impl TryFrom<EthersTransaction> for EthereumTxEssence {
                 value: from_ethers_u256(tx.value),
                 access_list: tx.access_list.context("access_list missing")?.into(),
                 data: tx.input.0.into(),
+            }),
+            Some(3) => EthereumTxEssence::Eip4844(TxEssenceEip4844 {
+                chain_id: tx
+                    .chain_id
+                    .context("chain_id missing")?
+                    .try_into()
+                    .map_err(|err| anyhow!("invalid chain_id: {}", err))?,
+                nonce: tx
+                    .nonce
+                    .try_into()
+                    .map_err(|err| anyhow!("invalid nonce: {}", err))?,
+                max_priority_fee_per_gas: from_ethers_u256(
+                    tx.max_priority_fee_per_gas
+                        .context("max_priority_fee_per_gas missing")?,
+                ),
+                max_fee_per_gas: from_ethers_u256(
+                    tx.max_fee_per_gas.context("max_fee_per_gas missing")?,
+                ),
+                gas_limit: from_ethers_u256(tx.gas),
+                to: tx.to.into(),
+                value: from_ethers_u256(tx.value),
+                access_list: tx.access_list.context("access_list missing")?.into(),
+                data: tx.input.0.into(),
+                blob_versioned_hashes: Default::default(),
+                max_fee_per_blob_gas: Default::default(),
             }),
             _ => unreachable!(),
         };

--- a/primitives/src/transactions/ethereum.rs
+++ b/primitives/src/transactions/ethereum.rs
@@ -211,6 +211,42 @@ pub struct TxEssenceEip1559 {
     pub access_list: AccessList,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize, RlpEncodable)]
+pub struct TxEssenceEip4844 {
+    /// The network's chain ID, ensuring the transaction is valid on the intended chain,
+    /// as introduced in EIP-155.
+    pub chain_id: ChainId,
+    /// A numeric value representing the total number of transactions previously sent by
+    /// the sender.
+    pub nonce: TxNumber,
+    /// The maximum priority fee per unit of gas that the sender is willing to pay to the
+    /// miner.
+    pub max_priority_fee_per_gas: U256,
+    /// The combined maximum fee (base + priority) per unit of gas that the sender is
+    /// willing to pay for the transaction's execution.
+    pub max_fee_per_gas: U256,
+    /// The maximum amount of gas allocated for the transaction's execution.
+    pub gas_limit: U256,
+    /// The 160-bit address of the intended recipient for a message call. For contract
+    /// creation transactions, this is null.
+    pub to: TransactionKind,
+    /// The amount, in Wei, to be transferred to the recipient of the message call.
+    pub value: U256,
+    /// The transaction's payload, represented as a variable-length byte array.
+    pub data: Bytes,
+    /// A list of addresses and storage keys that the transaction will access, aiding in
+    /// gas optimization.
+    pub access_list: AccessList,
+
+    /// It contains a vector of fixed size hash(32 bytes)
+    pub blob_versioned_hashes: Vec<B256>,
+
+    /// Max fee per data gas
+    ///
+    /// aka BlobFeeCap or blobGasFeeCap
+    pub max_fee_per_blob_gas: U256,
+}
+
 /// Represents the type of an Ethereum transaction: either a contract creation or a call
 /// to an existing contract.
 ///
@@ -298,6 +334,7 @@ pub enum EthereumTxEssence {
     /// This mechanism aims to improve the predictability of gas fees and enhances the
     /// overall user experience.
     Eip1559(TxEssenceEip1559),
+    Eip4844(TxEssenceEip4844),
 }
 
 // Implement the Encodable trait for the TxEssence enum.
@@ -313,6 +350,7 @@ impl Encodable for EthereumTxEssence {
             EthereumTxEssence::Legacy(tx) => tx.encode(out),
             EthereumTxEssence::Eip2930(tx) => tx.encode(out),
             EthereumTxEssence::Eip1559(tx) => tx.encode(out),
+            EthereumTxEssence::Eip4844(tx) => tx.encode(out),
         }
     }
 
@@ -326,6 +364,7 @@ impl Encodable for EthereumTxEssence {
             EthereumTxEssence::Legacy(tx) => tx.length(),
             EthereumTxEssence::Eip2930(tx) => tx.length(),
             EthereumTxEssence::Eip1559(tx) => tx.length(),
+            EthereumTxEssence::Eip4844(tx) => tx.length(),
         }
     }
 }
@@ -360,6 +399,12 @@ impl EthereumTxEssence {
             EthereumTxEssence::Eip1559(tx) => {
                 let mut buf = Vec::with_capacity(tx.length() + 1);
                 buf.push(0x02);
+                tx.encode(&mut buf);
+                buf
+            }
+            EthereumTxEssence::Eip4844(tx) => {
+                let mut buf = Vec::with_capacity(tx.length() + 1);
+                buf.push(0x03);
                 tx.encode(&mut buf);
                 buf
             }
@@ -412,6 +457,7 @@ impl TxEssence for EthereumTxEssence {
             EthereumTxEssence::Legacy(_) => 0x00,
             EthereumTxEssence::Eip2930(_) => 0x01,
             EthereumTxEssence::Eip1559(_) => 0x02,
+            EthereumTxEssence::Eip4844(_) => 0x03,
         }
     }
     /// Retrieves the gas limit set for the transaction.
@@ -423,6 +469,7 @@ impl TxEssence for EthereumTxEssence {
             EthereumTxEssence::Legacy(tx) => tx.gas_limit,
             EthereumTxEssence::Eip2930(tx) => tx.gas_limit,
             EthereumTxEssence::Eip1559(tx) => tx.gas_limit,
+            EthereumTxEssence::Eip4844(tx) => tx.gas_limit,
         }
     }
     /// Retrieves the recipient address of the transaction, if available.
@@ -434,6 +481,7 @@ impl TxEssence for EthereumTxEssence {
             EthereumTxEssence::Legacy(tx) => tx.to.into(),
             EthereumTxEssence::Eip2930(tx) => tx.to.into(),
             EthereumTxEssence::Eip1559(tx) => tx.to.into(),
+            EthereumTxEssence::Eip4844(tx) => tx.to.into(),
         }
     }
     /// Recovers the Ethereum address of the sender from the transaction's signature.
@@ -472,6 +520,7 @@ impl TxEssence for EthereumTxEssence {
             EthereumTxEssence::Legacy(tx) => tx.payload_length(),
             EthereumTxEssence::Eip2930(tx) => tx._alloy_rlp_payload_length(),
             EthereumTxEssence::Eip1559(tx) => tx._alloy_rlp_payload_length(),
+            EthereumTxEssence::Eip4844(tx) => tx._alloy_rlp_payload_length(),
         }
     }
 


### PR DESCRIPTION
This is a temporary solution. Holesky updated to Cankun few hours ago, but Raiko didn't know the type3 transaction. 