### PR TITLE
Use timestamp to slot instead of block height to query blob.

### DIFF
--- a/lib/src/consts.rs
+++ b/lib/src/consts.rs
@@ -65,6 +65,8 @@ pub static ETH_MAINNET_CHAIN_SPEC: Lazy<ChainSpec> = Lazy::new(|| {
         l1_contract: None,
         l2_contract: None,
         sgx_verifier_address: None,
+        genesis_time: 0u64,
+        seconds_per_slot: 1u64,
     }
 });
 
@@ -87,6 +89,8 @@ macro_rules! taiko_chain_spec {
                 l1_contract: Some(*L1_CONTRACT),
                 l2_contract: Some(*L2_CONTRACT),
                 sgx_verifier_address: Some(*SGX_VERIFIER_ADDRESS),
+                genesis_time: GENISES_TIME,
+                seconds_per_slot: SECONDS_PER_SLOT,
             }
         });
     };
@@ -118,6 +122,8 @@ pub static OP_MAINNET_CHAIN_SPEC: Lazy<ChainSpec> = Lazy::new(|| ChainSpec {
     l1_contract: None,
     l2_contract: None,
     sgx_verifier_address: None,
+    genesis_time: 0u64,
+    seconds_per_slot: 1u64,
 });
 
 /// The condition at which a fork is activated.
@@ -169,6 +175,8 @@ pub struct ChainSpec {
     pub l1_contract: Option<Address>,
     pub l2_contract: Option<Address>,
     pub sgx_verifier_address: Option<Address>,
+    pub genesis_time: u64,
+    pub seconds_per_slot: u64,
 }
 
 impl ChainSpec {
@@ -185,6 +193,8 @@ impl ChainSpec {
             l1_contract: None,
             l2_contract: None,
             sgx_verifier_address: None,
+            genesis_time: 0u64,
+            seconds_per_slot: 1u64,
         }
     }
     /// Returns the network chain ID.

--- a/lib/src/host/provider/rpc_provider.rs
+++ b/lib/src/host/provider/rpc_provider.rs
@@ -184,7 +184,11 @@ impl Provider for RpcProvider {
     fn get_blob_data(&mut self, block_id: u64) -> Result<GetBlobsResponse> {
         match self.beacon_rpc_url {
             Some(ref url) => self.tokio_handle.block_on(async {
-                let url = format!("{}/eth/v1/beacon/blob_sidecars/{}", url, block_id);
+                let url = format!(
+                    "{}/eth/v1/beacon/blob_sidecars/{}",
+                    url.trim_end_matches('/'),
+                    block_id
+                );
                 let response = reqwest::get(url.clone()).await?;
                 if response.status().is_success() {
                     let blob_response: GetBlobsResponse = response.json().await?;

--- a/lib/src/taiko/host.rs
+++ b/lib/src/taiko/host.rs
@@ -380,7 +380,7 @@ pub fn get_taiko_initial_data<N: NetworkStrategyBundle<TxEssence = EthereumTxEss
         assert!(blob_hashs.len() == 1);
         let blob_hash = blob_hashs[0];
         let slot_id = block_time_to_block_slot(
-            l2_fini_block.timestamp.as_u64(),
+            l1_next_block.timestamp.as_u64(),
             l2_chain_spec.genesis_time,
             l2_chain_spec.seconds_per_slot,
         )?;

--- a/primitives/src/taiko/consts.rs
+++ b/primitives/src/taiko/consts.rs
@@ -19,13 +19,15 @@ pub mod testnet {
             .expect("invalid l1 contract address")
     });
     pub static L2_CONTRACT: Lazy<Address> = Lazy::new(|| {
-        Address::from_str("0x1670080000000000000000000000000000010001")
+        Address::from_str("0x1670090000000000000000000000000000010001")
             .expect("invalid l2 contract address")
     });
     pub static SGX_VERIFIER_ADDRESS: Lazy<Address> = Lazy::new(|| {
         Address::from_str("0x914e458035Cd10B3650B4115D74f351f79EA768E")
             .expect("invalid sgx verifier contract address")
     });
+    pub const GENISES_TIME: u64 = 1695902400u64;
+    pub const SECONDS_PER_SLOT: u64 = 12u64;
 }
 
 pub mod internal_devnet_a {
@@ -43,6 +45,8 @@ pub mod internal_devnet_a {
         Address::from_str("0x558E38a3286916934Cb63ced04558A52F7Ce67a9")
             .expect("invalid sgx verifier contract address")
     });
+    pub const GENISES_TIME: u64 = 1695902400u64;
+    pub const SECONDS_PER_SLOT: u64 = 12u64;
 }
 
 pub mod internal_devnet_b {
@@ -60,4 +64,6 @@ pub mod internal_devnet_b {
         Address::from_str("0x558E38a3286916934Cb63ced04558A52F7Ce67a9")
             .expect("invalid sgx verifier contract address")
     });
+    pub const GENISES_TIME: u64 = 1695902400u64;
+    pub const SECONDS_PER_SLOT: u64 = 12u64;
 }

--- a/primitives/src/taiko/consts.rs
+++ b/primitives/src/taiko/consts.rs
@@ -13,9 +13,9 @@ pub static GOLDEN_TOUCH_ACCOUNT: Lazy<Address> = Lazy::new(|| {
 
 pub mod testnet {
     use super::*;
-    pub const CHAIN_ID: u64 = 167008;
+    pub const CHAIN_ID: u64 = 167009;
     pub static L1_CONTRACT: Lazy<Address> = Lazy::new(|| {
-        Address::from_str("0xB20BB9105e007Bd3E0F73d63D4D3dA2c8f736b77")
+        Address::from_str("0xaC6ccC4B3aBA6E96E2F58E0fF7A4ff3aF469E62E")
             .expect("invalid l1 contract address")
     });
     pub static L2_CONTRACT: Lazy<Address> = Lazy::new(|| {
@@ -23,7 +23,7 @@ pub mod testnet {
             .expect("invalid l2 contract address")
     });
     pub static SGX_VERIFIER_ADDRESS: Lazy<Address> = Lazy::new(|| {
-        Address::from_str("0x558E38a3286916934Cb63ced04558A52F7Ce67a9")
+        Address::from_str("0x914e458035Cd10B3650B4115D74f351f79EA768E")
             .expect("invalid sgx verifier contract address")
     });
 }


### PR DESCRIPTION
Because in mainnet, the slot number != block height