### PR TITLE
fix input.bin concurrency issue

### DIFF
--- a/provers/sgx/config/raiko-guest.manifest.template
+++ b/provers/sgx/config/raiko-guest.manifest.template
@@ -15,7 +15,7 @@ fs.mounts = [
   { path = "/usr/lib/ssl/certs/", uri = "file:/usr/lib/ssl/certs/" },
   { path = "/tmp", uri = "file:/tmp" },
   { path = "/root/.config/raiko/config", uri = "file:config" },
-  { path = "/input.bin", uri = "file:input.bin" },
+  { path = "/tmp/inputs", uri = "file:/tmp/inputs" },
 
   # encrypted files give an IO error in direct mode so just make it a normal file
   { path = "/root/.config/raiko/secrets", uri = "file:secrets" {{ ", type = 'encrypted', key_name = '_sgx_mrsigner'" if direct_mode != '1' else "" }} },
@@ -51,8 +51,7 @@ sys.enable_extra_runtime_domain_names_conf = true
 sgx.remote_attestation = "dcap"
 
 sgx.allowed_files = [
-  "file:/tmp/sgx",
   "file:config",
-  "file:input.bin",
+  "file:/tmp/inputs",
   {{ " 'file:secrets', " if direct_mode == '1' else ""}}
 ]

--- a/provers/sgx/guest/src/app_args.rs
+++ b/provers/sgx/guest/src/app_args.rs
@@ -23,7 +23,7 @@ pub enum Command {
 
 #[derive(Debug, Args)]
 pub struct OneShotArgs {
-    #[clap(long, default_value = "./input.bin")]
+    #[clap(long, required = true)]
     pub blocks_data_file: PathBuf,
     #[clap(long)]
     pub sgx_instance_id: u32,

--- a/provers/sgx/prover/src/lib.rs
+++ b/provers/sgx/prover/src/lib.rs
@@ -107,7 +107,6 @@ impl Prover for SgxProver {
         let sgx_proof = if config.prove {
             prove(
                 &mut gramine_cmd(),
-                &cur_dir,
                 input,
                 config.instance_id,
                 config.input_path,
@@ -214,21 +213,30 @@ async fn bootstrap(gramine_cmd: &mut Command) -> ProverResult<SgxResponse, Strin
     Ok(SgxResponse::default())
 }
 
+fn get_default_raiko_sgx_inputs_path(sub_dir: &str) -> PathBuf {
+    let input_dir = PathBuf::from("/tmp/inputs");
+    input_dir.join(sub_dir)
+}
+
 async fn prove(
     gramine_cmd: &mut Command,
-    cur_dir: &PathBuf,
     input: GuestInput,
     instance_id: u64,
     input_path: Option<PathBuf>,
 ) -> ProverResult<SgxResponse, ProverError> {
     // If cached input file is not provided
     // write the input to a file that will be read by the SGX instance
-    let _input_path = match input_path {
+    let input_path = match input_path {
         Some(path) => path.clone(),
         None => {
-            let path = cur_dir.join(INPUT_FILE_NAME);
-            bincode::serialize_into(File::create(&path).expect("Unable to open file"), &input)
-                .expect("Unable to serialize input");
+            let path = get_default_raiko_sgx_inputs_path(
+                &(input.taiko.block_proposed.meta.id.to_string() + ".bin"),
+            );
+            bincode::serialize_into(
+                File::create(&path).expect("Unable to open input file"),
+                &input,
+            )
+            .expect("Unable to serialize input");
             path
         }
     };
@@ -238,6 +246,8 @@ async fn prove(
         .arg("one-shot")
         .arg("--sgx-instance-id")
         .arg(instance_id.to_string())
+        .arg("--blocks-data-file")
+        .arg(input_path)
         .output()
         .await
         .map_err(|e| format!("Could not run SGX guest prover: {}", e))?;


### PR DESCRIPTION
use block_id.bin instead of input.bin to avoid race condition in concurrency use scenario.