### PR TITLE
Fix SGX manifest file path + better error handling

### DIFF
--- a/host/src/execution.rs
+++ b/host/src/execution.rs
@@ -59,12 +59,14 @@ pub async fn execute<D: Prover>(
             let res = D::run(input.clone(), output, config)
                 .await
                 .map(|proof| (input, proof))
-                .map_err(|e| HostError::GuestError(e.to_string()));
+                .map_err(|e| HostError::GuestError(e.to_string()))?;
+
             measurement.stop_with("=> Proof generated");
             memory::print_stats("Prover peak memory used: ");
 
             total_proving_time.stop_with("====> Complete proof generated");
-            res
+
+            Ok(res)
         }
         Err(e) => {
             warn!("Proving bad block construction!");

--- a/host/src/server.rs
+++ b/host/src/server.rs
@@ -179,6 +179,7 @@ impl Handler {
                     .await;
                 let payload = match result {
                     Err(err) => {
+                        println!("Error: {}", err.to_string());
                         serde_json::to_vec(&JsonRpcResponseError {
                             jsonrpc: "2.0".to_string(),
                             id: json_req.id,

--- a/provers/sgx/prover/src/lib.rs
+++ b/provers/sgx/prover/src/lib.rs
@@ -300,7 +300,7 @@ fn handle_output(output: &Output, name: &str) -> ProverResult<(), String> {
     );
     if !output.status.success() {
         return Err(format!(
-            "{} encountered an error {}: {}",
+            "{} encountered an error ({}): {}",
             name,
             output.status.to_string(),
             String::from_utf8_lossy(&output.stderr),


### PR DESCRIPTION
The path to the local manifest was not updated, so the copy failed.

However, if you didn't check the output you would not have noticed because we did not check the status of the command, so if the manifest was already there from before a proof could actually be successfully generated and everything would look alright, though with an outdated manifest file. So I changed things so that the status is checked for all commands and raiko doesn't make it look like a proof was generated when an error is encountered during the proving.