### PR TITLE
Show quote in bootstrap command and make loading bootsrap testable.

### DIFF
--- a/provers/sgx/guest/src/one_shot.rs
+++ b/provers/sgx/guest/src/one_shot.rs
@@ -104,7 +104,7 @@ pub fn bootstrap(global_opts: GlobalOpts) -> Result<()> {
 pub async fn one_shot(global_opts: GlobalOpts, args: OneShotArgs) -> Result<()> {
     // Make sure this SGX instance was bootstrapped
     let prev_privkey = load_bootstrap(&global_opts.secrets_dir)
-        .or_else(|_| bail!("Application was not bootstrapped. Bootstrap it first."))
+        .or_else(|_| bail!("Application was not bootstrapped or has a deprecated bootstrap."))
         .unwrap();
 
     println!("Global options: {global_opts:?}, OneShot options: {args:?}");

--- a/provers/sgx/guest/src/one_shot.rs
+++ b/provers/sgx/guest/src/one_shot.rs
@@ -12,7 +12,7 @@ use raiko_lib::{
     protocol_instance::{assemble_protocol_instance, EvidenceType},
 };
 use raiko_primitives::Address;
-use secp256k1::KeyPair;
+use secp256k1::{KeyPair, SecretKey};
 use serde::Serialize;
 base64_serde_type!(Base64Standard, base64::engine::general_purpose::STANDARD);
 
@@ -67,6 +67,8 @@ fn save_bootstrap_details(
         new_instance,
         quote: hex::encode(quote),
     };
+
+    println!("{}", serde_json::json!(&bootstrap_details));
     let json = serde_json::to_string_pretty(&bootstrap_details)?;
     fs::write(bootstrap_details_file_path, json).context(format!(
         "Saving bootstrap data file {} failed",
@@ -101,16 +103,12 @@ pub fn bootstrap(global_opts: GlobalOpts) -> Result<()> {
 
 pub async fn one_shot(global_opts: GlobalOpts, args: OneShotArgs) -> Result<()> {
     // Make sure this SGX instance was bootstrapped
-    if !is_bootstrapped(&global_opts.secrets_dir) {
-        bail!("Application was not bootstrapped. Bootstrap it first.");
-    }
+    let prev_privkey = load_bootstrap(&global_opts.secrets_dir)
+        .or_else(|_| bail!("Application was not bootstrapped. Bootstrap it first."))
+        .unwrap();
 
     println!("Global options: {global_opts:?}, OneShot options: {args:?}");
 
-    // Load the signing data
-    let privkey_path = global_opts.secrets_dir.join(PRIV_KEY_FILENAME);
-    let prev_privkey = load_private_key(privkey_path)?;
-    // let (new_privkey, new_pubkey) = generate_new_keypair()?;
     let new_pubkey = public_key(&prev_privkey);
     let new_instance = public_key_to_address(&new_pubkey);
 
@@ -156,9 +154,22 @@ pub async fn one_shot(global_opts: GlobalOpts, args: OneShotArgs) -> Result<()> 
     print_sgx_info()
 }
 
-fn is_bootstrapped(secrets_dir: &Path) -> bool {
+fn load_bootstrap(secrets_dir: &Path) -> Result<SecretKey, Error> {
     let privkey_path = secrets_dir.join(PRIV_KEY_FILENAME);
-    privkey_path.is_file() && !privkey_path.metadata().unwrap().permissions().readonly()
+    if privkey_path.is_file() && !privkey_path.metadata().unwrap().permissions().readonly() {
+        load_private_key(&privkey_path).map_err(|e| {
+            anyhow!(
+                "Failed to load private key from {}: {}",
+                privkey_path.display(),
+                e
+            )
+        })
+    } else {
+        Err(anyhow!(
+            "No readable private key found in {}",
+            privkey_path.display()
+        ))
+    }
 }
 
 fn save_attestation_user_report_data(pubkey: Address) -> Result<()> {

--- a/provers/sgx/prover/src/lib.rs
+++ b/provers/sgx/prover/src/lib.rs
@@ -109,16 +109,17 @@ impl Prover for SgxProver {
             setup(&cur_dir, direct_mode).await?;
         }
 
-        let sgx_proof = if config.bootstrap {
+        let mut sgx_proof = if config.bootstrap {
             bootstrap(cur_dir.clone(), gramine_cmd()).await
-        } else if config.prove {
-            // now prove can not go with bootstrap as we need manually register sgx id.
-            // TODO: auto register sgx id
-            prove(gramine_cmd(), input.clone(), config.instance_id).await
         } else {
             // Dummy proof: it's ok when only setup/bootstrap was requested
             Ok(SgxResponse::default())
         };
+
+        if config.prove {
+            // overwirte sgx_proof as the bootstrap quote stays the same in bootstrap & prove.
+            sgx_proof = prove(gramine_cmd(), input.clone(), config.instance_id).await
+        }
 
         to_proof(sgx_proof)
     }


### PR DESCRIPTION
Return quote when client request bootstrap without proof (as bootstrap does not have it). Then caller can see the quote remotely, rather then open a local file.
Also change is_bootstrap to load_bootstrap to test if a bootstrap file is loadable, which is the 1st step of automatically register on-chain sgx id, ref: https://github.com/taikoxyz/raiko/issues/108