### PR TITLE
hotfix: align calldata path check with client

### DIFF
--- a/provers/sgx/prover/src/lib.rs
+++ b/provers/sgx/prover/src/lib.rs
@@ -4,13 +4,12 @@ use std::{
     fs::{copy, create_dir_all, remove_file},
     path::PathBuf,
     process::{Command as StdCommand, Output, Stdio},
-    str::{self, FromStr},
+    str,
 };
 
 use alloy_sol_types::SolValue;
 use once_cell::sync::Lazy;
 use raiko_lib::{
-    consts::{get_network_spec, Network},
     input::{GuestInput, GuestOutput},
     protocol_instance::ProtocolInstance,
     prover::{to_proof, Proof, Prover, ProverConfig, ProverError, ProverResult},


### PR DESCRIPTION
Align calldata checking logic with client.
However, in main branch, we should check the size before decompress. So, we make release tag from this PR, and after it, the A7 release branch will diverge from unstable.