### PR TITLE
fix(lib): temporarily disable kzg check in sgx/sp1 provers

### DIFF
--- a/host/config/config.json
+++ b/host/config/config.json
@@ -7,8 +7,8 @@
     "prover_args": {
         "sgx": {
             "instance_id": 456,
-            "setup": false,
-            "bootstrap": false,
+            "setup": true,
+            "bootstrap": true,
             "prove": true,
             "input_path": null
         },

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -57,4 +57,4 @@ std = [
 ]
 sgx = []
 sp1 = []
-risc = []
+risc0 = []

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -55,3 +55,6 @@ std = [
   "dep:serde_with",
   # "dep:tokio",
 ]
+sgx = []
+sp1 = []
+risc = []

--- a/lib/src/protocol_instance.rs
+++ b/lib/src/protocol_instance.rs
@@ -95,16 +95,25 @@ pub fn assemble_protocol_instance(
 ) -> Result<ProtocolInstance> {
     let blob_used = input.taiko.block_proposed.meta.blobUsed;
     let tx_list_hash = if blob_used {
-        let mut data = Vec::from(KZG_TRUST_SETUP_DATA);
-        let kzg_settings = KzgSettings::from_u8_slice(&mut data);
-        let kzg_commit = KzgCommitment::blob_to_kzg_commitment(
-            &Blob::from_bytes(&input.taiko.tx_data.as_slice()).unwrap(),
-            &kzg_settings,
-        )
-        .unwrap();
-        let versioned_hash = kzg_to_versioned_hash(kzg_commit);
-        assert_eq!(versioned_hash, input.taiko.tx_blob_hash.unwrap());
-        versioned_hash
+        #[cfg(not(any(feature = "sgx", feature = "sp1")))]
+        {
+            println!("kzg check enabled!");
+            let mut data = Vec::from(KZG_TRUST_SETUP_DATA);
+            let kzg_settings = KzgSettings::from_u8_slice(&mut data);
+            let kzg_commit = KzgCommitment::blob_to_kzg_commitment(
+                &Blob::from_bytes(&input.taiko.tx_data.as_slice()).unwrap(),
+                &kzg_settings,
+            )
+            .unwrap();
+            let versioned_hash = kzg_to_versioned_hash(kzg_commit);
+            assert_eq!(versioned_hash, input.taiko.tx_blob_hash.unwrap());
+            versioned_hash
+        }
+        #[cfg(any(feature = "sgx", feature = "sp1"))]
+        {
+            println!("kzg check disabled!");
+            input.taiko.tx_blob_hash.unwrap()
+        }
     } else {
         TxHash::from(keccak(input.taiko.tx_data.as_slice()))
     };

--- a/provers/risc0/guest/Cargo.toml
+++ b/provers/risc0/guest/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 
 [dependencies]
 raiko-primitives = { path = "../../../primitives" }
-raiko-lib = { path = "../../../lib", features = ["std"] }
+raiko-lib = { path = "../../../lib", features = ["std", "risc0"] }
 risc0-zkvm = { version = "0.21.0", default-features = false, features = ['std', "getrandom"] }
 
 [dev-dependencies]

--- a/provers/sgx/guest/Cargo.toml
+++ b/provers/sgx/guest/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-raiko-lib = { workspace = true }
+raiko-lib = { workspace = true, features = ["sgx"] }
 raiko-primitives = { workspace = true }
 tokio = { workspace = true }
 anyhow = { workspace = true }

--- a/provers/sp1/guest/Cargo.toml
+++ b/provers/sp1/guest/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-raiko-lib = { path = "../../../lib", features = ["std"] }
+raiko-lib = { path = "../../../lib", features = ["std", "sp1"] }
 sp1-zkvm ={ git = "https://github.com/succinctlabs/sp1.git", branch = "main" }
 
 [dev-dependencies]


### PR DESCRIPTION
Some problems in SGX and SP1 while proving with the kzg check, so I temporarily disabled them in those provers. Well actually it is currently always disabled because sgx is enabled in the workspace so it will always compile the lib with that feature on, so using features not exactly the best way to do these kind of prover specific things unfortunately.

In SGX (direct mode):

![image](https://github.com/taikoxyz/raiko/assets/7032473/9cd5d026-114e-4ff5-a61b-0526cab998ec)


In SP1:

![image](https://github.com/taikoxyz/raiko/assets/7032473/0253b8b6-1e3c-4400-aa7c-926a29bfa3a8)
