### PR TITLE
cargo: sync the edition of all packages

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,10 +9,13 @@ members = [
     "provers/risc0/driver",
     "provers/risc0/builder",
     "provers/sgx/prover",
-    "provers/sgx/guest", 
+    "provers/sgx/guest",
     "provers/sgx/setup",
     "pipeline",
 ]
+
+[workspace.package]
+edition = "2021"
 
 # Always optimize; building and running the guest takes much longer without optimization.
 [profile.dev]

--- a/host/Cargo.toml
+++ b/host/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "raiko-host"
 version = "0.1.0"
-edition = "2021"
+edition = { workspace = true }
 default-run = "raiko-host"
 
 [dependencies]

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "raiko-lib"
 version = "0.1.0"
-edition = "2021"
+edition = { workspace = true }
 
 [dependencies]
 raiko-primitives = { workspace = true }

--- a/pipeline/examples/builder/Cargo.toml
+++ b/pipeline/examples/builder/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "builder"
 version = "0.1.0"
-edition = "2021"
+edition = { workspace = true }
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -12,4 +12,3 @@ raiko-pipeline = { workspace = true }
 [features]
 sp1 = ["raiko-pipeline/sp1"]
 risc0 = ["raiko-pipeline/risc0"]
-

--- a/pipeline/examples/driver/Cargo.toml
+++ b/pipeline/examples/driver/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "driver"
 version = "0.1.0"
-edition = "2021"
+edition = { workspace = true }
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -16,4 +16,3 @@ methods = { path = "../risc0/methods", optional = true }
 # default = ["sp1", "risc0"]
 sp1 = ["dep:sp1-sdk"]
 risc0 = ["dep:risc0-zkvm", "dep:methods"]
-

--- a/pipeline/examples/risc0/Cargo.toml
+++ b/pipeline/examples/risc0/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "example"
 version = "0.1.0"
-edition = "2021"
+edition = { workspace = true }
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/pipeline/examples/risc0/methods/Cargo.toml
+++ b/pipeline/examples/risc0/methods/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "methods"
 version = "0.1.0"
-edition = "2021"
+edition = { workspace = true }
 
 [workspace]

--- a/pipeline/examples/sp1/Cargo.toml
+++ b/pipeline/examples/sp1/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "example"
 version = "0.1.0"
-edition = "2021"
+edition = { workspace = true }
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/pipeline/harness/Cargo.toml
+++ b/pipeline/harness/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "harness"
 version = "0.1.0"
-edition = "2021"
+edition = { workspace = true }
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/primitives/Cargo.toml
+++ b/primitives/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "raiko-primitives"
 version = "0.1.0"
-edition = "2021"
+edition = { workspace = true }
 
 [dependencies]
 alloy-primitives = { workspace = true }

--- a/provers/powdr/Cargo.toml
+++ b/provers/powdr/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "powdr"
 version = "0.1.0"
-edition = "2021"
+edition = { workspace = true }
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -21,4 +21,3 @@ powdr-riscv-runtime ={ git = "https://github.com/ceciliaz030/powdr", branch = "+
 
 
 # cargo build --release -Z build-std=core,alloc --target riscv32imac-unknown-none-elf --lib
-

--- a/provers/risc0/builder/Cargo.toml
+++ b/provers/risc0/builder/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "risc0-builder"
 version = "0.1.0"
-edition = "2021"
+edition = { workspace = true }
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/provers/risc0/driver/Cargo.toml
+++ b/provers/risc0/driver/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "risc0-driver"
 version = "0.1.0"
-edition = "2021"
+edition = { workspace = true }
 
 [dependencies]
 raiko-lib = { workspace = true, optional = true }

--- a/provers/risc0/guest/Cargo.toml
+++ b/provers/risc0/guest/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "risc0-guest"
 version = "0.1.0"
-edition = "2021"
+edition = { workspace = true }
 
 [workspace]
 

--- a/provers/sgx/guest/Cargo.toml
+++ b/provers/sgx/guest/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "sgx-guest"
 version = "0.1.0"
-edition = "2021"
+edition = { workspace = true }
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/provers/sgx/prover/Cargo.toml
+++ b/provers/sgx/prover/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "sgx-prover"
 version = "0.1.0"
-edition = "2021"
+edition = { workspace = true }
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/provers/sgx/setup/Cargo.toml
+++ b/provers/sgx/setup/Cargo.toml
@@ -2,7 +2,7 @@
 [package]
 name = "raiko-setup"
 version = "0.1.0"
-edition = "2021"
+edition = { workspace = true }
 
 [dependencies]
 # sp1-driver = { path = "../provers/sp1/driver", optional = true }

--- a/provers/sp1/builder/Cargo.toml
+++ b/provers/sp1/builder/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "sp1-builder"
 version = "0.1.0"
-edition = "2021"
+edition = { workspace = true }
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/provers/sp1/driver/Cargo.toml
+++ b/provers/sp1/driver/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 version = "0.1.0"
 name = "sp1-driver"
-edition = "2021"
+edition = { workspace = true }
 
 [dependencies]
 raiko-lib = { workspace = true, optional = true }

--- a/provers/sp1/guest/Cargo.toml
+++ b/provers/sp1/guest/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "sp1-guest"
 version = "0.1.0"
-edition = "2021"
+edition = { workspace = true }
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -21,4 +21,4 @@ sp1-precompiles = { git = "https://www.github.com/succinctlabs/sp1.git", branch 
 
 [workspace]
 
-# cargo prove build 
+# cargo prove build


### PR DESCRIPTION
Self-explanatory, Rust edition 2024 is underway so that would be a single location to switch, if we need to.

https://doc.rust-lang.org/nightly/edition-guide/rust-2024/index.html