### PR TITLE
fix(raiko): fix sticky invalid tx state

### DIFF
--- a/host/src/preflight.rs
+++ b/host/src/preflight.rs
@@ -305,7 +305,7 @@ async fn get_blob_data_beacon(
         // pub signed_block_header: SignedBeaconBlockHeader, // ignore for now
         pub kzg_commitment: String,
         pub kzg_proof: String,
-        pub kzg_commitment_inclusion_proof: Vec<String>,
+        //pub kzg_commitment_inclusion_proof: Vec<String>,
     }
 
     #[derive(Clone, Debug, Deserialize, Serialize)]

--- a/host/src/raiko.rs
+++ b/host/src/raiko.rs
@@ -286,7 +286,7 @@ mod tests {
             block_number,
             rpc: "https://rpc.hekla.taiko.xyz".to_string(),
             l1_rpc: "https://ethereum-holesky-rpc.publicnode.com".to_string(),
-            beacon_rpc: "https://api.holesky.blobscan.com".to_string(),
+            beacon_rpc: "https://eth-holesky-beacon.public.blastapi.io".to_string(),
             network,
             graffiti: B256::ZERO,
             prover: Address::ZERO,

--- a/lib/src/builder/execute.rs
+++ b/lib/src/builder/execute.rs
@@ -235,6 +235,9 @@ impl TxExecStrategy for TkoTxExecStrategy {
             let ResultAndState { result, state } = match evm.transact() {
                 Ok(result) => result,
                 Err(err) => {
+                    // Clear the state for the next tx
+                    evm.context.evm.journaled_state = JournaledState::new(spec_id, HashSet::new());
+
                     if is_optimistic {
                         continue;
                     }
@@ -250,9 +253,6 @@ impl TxExecStrategy for TkoTxExecStrategy {
                         EVMError::Transaction(invalid_transaction) => {
                             #[cfg(feature = "std")]
                             debug!("Invalid tx at {tx_no}: {invalid_transaction:?}");
-                            // Clear the state
-                            evm.context.evm.journaled_state =
-                                JournaledState::new(spec_id, HashSet::new());
                             // skip the tx
                             continue;
                         }

--- a/lib/src/builder/execute.rs
+++ b/lib/src/builder/execute.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use core::{fmt::Debug, mem::take, str::from_utf8};
+use std::collections::HashSet;
 
 use alloy_consensus::{constants::BEACON_ROOTS_ADDRESS, TxEnvelope};
 use alloy_primitives::{TxKind, U256};
@@ -29,7 +30,7 @@ use revm::{
         Account, Address, EVMError, HandlerCfg, ResultAndState, SpecId, TransactTo, TxEnv,
         MAX_BLOB_GAS_PER_BLOCK,
     },
-    taiko, Database, DatabaseCommit, Evm,
+    taiko, Database, DatabaseCommit, Evm, JournaledState,
 };
 
 use super::{OptimisticDatabase, TxExecStrategy};
@@ -249,6 +250,9 @@ impl TxExecStrategy for TkoTxExecStrategy {
                         EVMError::Transaction(invalid_transaction) => {
                             #[cfg(feature = "std")]
                             debug!("Invalid tx at {tx_no}: {invalid_transaction:?}");
+                            // Clear the state
+                            evm.context.evm.journaled_state =
+                                JournaledState::new(spec_id, HashSet::new());
                             // skip the tx
                             continue;
                         }

--- a/script/prove-block.sh
+++ b/script/prove-block.sh
@@ -35,7 +35,7 @@ elif [ "$chain" == "taiko_a6" ]; then
 elif [ "$chain" == "taiko_a7" ]; then
 	rpc="https://rpc.hekla.taiko.xyz"
 	l1Rpc="https://ethereum-holesky-rpc.publicnode.com"
-	beaconRpc="https://api.holesky.blobscan.com"
+	beaconRpc="https://eth-holesky-beacon.public.blastapi.io"
 else
 	echo "Invalid chain name. Please use 'ethereum', 'taiko_a6' or 'taiko_a7'."
 	exit 1


### PR DESCRIPTION
There's a couple of ways to clear the sticky tx state, not sure if this is the cleanest one but seems to work.

I think it's okay to set the list of warm addresses to empty without removing the addresses that should still be warm, but not 100% sure about this.