### PR TITLE
fix: mismatch method signature of libc's calloc

### DIFF
--- a/provers/risc0/guest/src/mem.rs
+++ b/provers/risc0/guest/src/mem.rs
@@ -3,13 +3,12 @@ use std::{
     ffi::c_void,
 };
 
-/// This is a basic implementation of custom memory allocation functions that mimic C-style memory management. 
-/// This implementation is designed to be used in ZkVM where we cross-compile Rust code with C 
+/// This is a basic implementation of custom memory allocation functions that mimic C-style memory management.
+/// This implementation is designed to be used in ZkVM where we cross-compile Rust code with C
 /// due to the dependency of c-kzg. This modification also requires env var:
 ///     $ CC="gcc"
 ///     $ CC_riscv32im-risc0-zkvm-elf="/opt/riscv/bin/riscv32-unknown-elf-gcc"
 /// which is set in the build pipeline
-
 
 #[no_mangle]
 // TODO ideally this is c_size_t, but not stabilized (not guaranteed to be usize on all archs)
@@ -26,8 +25,8 @@ pub unsafe extern "C" fn malloc(size: usize) -> *mut c_void {
 
 #[no_mangle]
 // TODO shouldn't need to zero allocated bytes since the zkvm memory is zeroed, might want to zero anyway
-pub unsafe extern "C" fn calloc(size: usize) -> *mut c_void {
-    malloc(size)
+unsafe extern "C" fn calloc(nobj: usize, size: usize) -> *mut c_void {
+    malloc(nobj * size)
 }
 
 #[no_mangle]

--- a/provers/risc0/guest/src/mem.rs
+++ b/provers/risc0/guest/src/mem.rs
@@ -25,7 +25,7 @@ pub unsafe extern "C" fn malloc(size: usize) -> *mut c_void {
 
 #[no_mangle]
 // TODO shouldn't need to zero allocated bytes since the zkvm memory is zeroed, might want to zero anyway
-unsafe extern "C" fn calloc(nobj: usize, size: usize) -> *mut c_void {
+pub unsafe extern "C" fn calloc(nobj: usize, size: usize) -> *mut c_void {
     malloc(nobj * size)
 }
 

--- a/provers/sp1/guest/src/mem.rs
+++ b/provers/sp1/guest/src/mem.rs
@@ -25,7 +25,7 @@ pub unsafe extern "C" fn malloc(size: usize) -> *mut c_void {
 
 #[no_mangle]
 // TODO shouldn't need to zero allocated bytes since the zkvm memory is zeroed, might want to zero anyway
-unsafe extern "C" fn calloc(nobj: usize, size: usize) -> *mut c_void {
+pub unsafe extern "C" fn calloc(nobj: usize, size: usize) -> *mut c_void {
     malloc(nobj * size)
 }
 

--- a/provers/sp1/guest/src/mem.rs
+++ b/provers/sp1/guest/src/mem.rs
@@ -25,8 +25,8 @@ pub unsafe extern "C" fn malloc(size: usize) -> *mut c_void {
 
 #[no_mangle]
 // TODO shouldn't need to zero allocated bytes since the zkvm memory is zeroed, might want to zero anyway
-pub unsafe extern "C" fn calloc(size: usize) -> *mut c_void {
-    malloc(size)
+unsafe extern "C" fn calloc(nobj: usize, size: usize) -> *mut c_void {
+    malloc(nobj * size)
 }
 
 #[no_mangle]


### PR DESCRIPTION
https://docs.rs/libc/latest/libc/fn.calloc.html

```rust
pub fn calloc(nobj: size_t, size: size_t) -> *mut c_void;
```