### PR TITLE
feat: lock the setup for sharing instance

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2563,6 +2563,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
+name = "file-lock"
+version = "2.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "040b48f80a749da50292d0f47a1e2d5bf1d772f52836c07f64bfccc62ba6e664"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
 name = "find_cuda_helper"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5010,6 +5020,7 @@ dependencies = [
  "dirs",
  "env_logger",
  "ethers-core",
+ "file-lock",
  "flate2",
  "hyper 0.14.28",
  "lazy_static",

--- a/provers/sgx/setup/Cargo.toml
+++ b/provers/sgx/setup/Cargo.toml
@@ -57,6 +57,7 @@ url = { workspace = true }
 cfg-if = { workspace = true }
 cap = { workspace = true }
 dirs = { workspace = true }
+file-lock = "2.1.11"
 
 [dev-dependencies]
 assert_cmd = { workspace = true }
@@ -76,7 +77,4 @@ default = ["sgx"]
 #   "dep:risc0-driver",
 #   "risc0-driver/enable",
 # ]
-sgx = [
-  "dep:sgx-prover",
-  "sgx-prover/enable",
-]
+sgx = ["dep:sgx-prover", "sgx-prover/enable"]


### PR DESCRIPTION
Share the registered specifications by sharing the persistent volume. We need to lock the entire setup process to prevent data races.