### PR TITLE
docs: Fix example using the prove-block.sh

### DIFF
--- a/docs/README_Docker_and_RA.md
+++ b/docs/README_Docker_and_RA.md
@@ -437,7 +437,7 @@ Once your Raiko instance is running, you can verify if it was started properly a
 }'
 ```
 
-Or use `./script/prove-block` like `./script/prove-block.sh taiko_a7 native 99999` to check readiness.
+Or use `./script/prove-block.sh` like `./script/prove-block.sh taiko_a7 sgx 99999` to check readiness.
 
 
 The response should look like this:


### PR DESCRIPTION
The example uses a `native' proof type which is not the same as the curl call above and does not return a proof or quote.

The curl example uses:  ```"prove": true``` which is passed as a parameter when using ``` "$proof" == "sgx" ```.

curl:

```
 curl --location 'http://localhost:8080' \
--header 'Content-Type: application/json' \
--data '{
    "proof_type": "sgx",
    "block_number": 99999,
    "prover": "0x7b399987d24fc5951f3e94a4cb16e87414bf2229",
    "graffiti": "0x0000000000000000000000000000000000000000000000000000000000000000",
    "sgx": {
        **"setup": false,
        "bootstrap": false,
        "prove": true**
    }
}'
```


prove-block.sh:

```
if [ "$proof" == "native" ]; then
	proofParam='
    "proof_type": "native"
  '

...

elif [ "$proof" == "sgx" ]; then
	proofParam='
    "proof_type": "sgx",
    "sgx" : {
        "instance_id": 123,
        **"setup": false,
        "bootstrap": false,
        "prove": true,**
        "input_path": null
    }
    '
```