### PR TITLE
fix(Risc-V toolchain): don't hardcode absolute path in /opt

### DIFF
--- a/provers/risc0/builder/src/main.rs
+++ b/provers/risc0/builder/src/main.rs
@@ -35,7 +35,7 @@ impl Pipeline for Risc0Pipeline {
             ])
             .cc_compiler("gcc".into())
             .c_flags(&[
-                "/opt/riscv/bin/riscv32-unknown-elf-gcc",
+                "riscv32-unknown-elf-gcc",
                 "-march=rv32im",
                 "-mstrict-align",
                 "-falign-functions=2",

--- a/provers/risc0/guest/src/mem.rs
+++ b/provers/risc0/guest/src/mem.rs
@@ -7,7 +7,7 @@ use std::{
 /// This implementation is designed to be used in ZkVM where we cross-compile Rust code with C
 /// due to the dependency of c-kzg. This modification also requires env var:
 ///     $ CC="gcc"
-///     $ CC_riscv32im-risc0-zkvm-elf="/opt/riscv/bin/riscv32-unknown-elf-gcc"
+///     $ CC_riscv32im-risc0-zkvm-elf="riscv32-unknown-elf-gcc"
 /// which is set in the build pipeline
 
 #[no_mangle]

--- a/provers/sp1/builder/src/main.rs
+++ b/provers/sp1/builder/src/main.rs
@@ -38,7 +38,7 @@ impl Pipeline for Sp1Pipeline {
             ])
             .cc_compiler("gcc".into())
             .c_flags(&[
-                "/opt/riscv/bin/riscv32-unknown-elf-gcc",
+                "riscv32-unknown-elf-gcc",
                 "-march=rv32im",
                 "-mstrict-align",
                 "-falign-functions=2",

--- a/provers/sp1/guest/src/mem.rs
+++ b/provers/sp1/guest/src/mem.rs
@@ -7,7 +7,7 @@ use std::{
 /// This implementation is designed to be used in ZkVM where we cross-compile Rust code with C
 /// due to the dependency of c-kzg. This modification also requires env var:
 ///     $ CC="gcc"
-///     $ CC_riscv32im-risc0-zkvm-elf="/opt/riscv/bin/riscv32-unknown-elf-gcc"
+///     $ CC_riscv32im-risc0-zkvm-elf="riscv32-unknown-elf-gcc"
 /// which is set in the build pipeline
 
 #[no_mangle]


### PR DESCRIPTION
The installation path of `riscv32-unknown-elf-gcc` is distro-specific. For example in mine it's in the standard `/usr/bin`, instead of non-standard `/opt/riscv/bin/`

![image](https://github.com/taikoxyz/raiko/assets/22738317/aec33bf6-8f06-437f-bc4d-0136db070630)

The standard way to make binary available regardless of physical location (local, opt, /usr/bin)  is to add them to $PATH, which I assume any installer is doing.