### PR TITLE
feat(raiko): refine error return to avoid incorrect status.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7305,6 +7305,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with 3.9.0",
+ "thiserror",
  "tokio",
  "tokio-util",
  "tracing",

--- a/provers/risc0/driver/Cargo.toml
+++ b/provers/risc0/driver/Cargo.toml
@@ -38,6 +38,7 @@ reqwest = { workspace = true, optional = true }
 lazy_static = { workspace = true, optional = true }
 tokio = { workspace = true }
 tokio-util = { workspace = true }
+thiserror = { workspace = true }
 
 [features]
 enable = [
@@ -62,7 +63,7 @@ enable = [
     "serde_json",
     "hex",
     "reqwest",
-    "lazy_static"
+    "lazy_static",
 ]
 cuda = ["risc0-zkvm?/cuda"]
 metal = ["risc0-zkvm?/metal"]

--- a/provers/risc0/driver/src/bonsai.rs
+++ b/provers/risc0/driver/src/bonsai.rs
@@ -41,7 +41,7 @@ pub async fn verify_bonsai_receipt<O: Eq + Debug + DeserializeOwned>(
     expected_output: &O,
     uuid: String,
     max_retries: usize,
-) -> anyhow::Result<(String, Receipt), BonsaiExecutionError> {
+) -> Result<(String, Receipt), BonsaiExecutionError> {
     info!("Tracking receipt uuid: {uuid}");
     let session = bonsai_sdk::alpha::SessionId { uuid };
 

--- a/provers/risc0/driver/src/bonsai.rs
+++ b/provers/risc0/driver/src/bonsai.rs
@@ -248,7 +248,7 @@ pub async fn prove_bonsai<O: Eq + Debug + DeserializeOwned>(
     assumption_uuids: Vec<String>,
     proof_key: ProofKey,
     id_store: &mut Option<&mut dyn IdWrite>,
-) -> anyhow::Result<(String, Receipt), BonsaiExecutionError> {
+) -> Result<(String, Receipt), BonsaiExecutionError> {
     info!("Proving on Bonsai");
     // Compute the image_id, then upload the ELF with the image_id as its key.
     let image_id = risc0_zkvm::compute_image_id(elf)

--- a/provers/sp1/driver/src/lib.rs
+++ b/provers/sp1/driver/src/lib.rs
@@ -122,7 +122,11 @@ impl Prover for Sp1Prover {
             let proof_id = network_prover
                 .request_proof(ELF, stdin, param.recursion.clone().into())
                 .await
-                .map_err(|_| ProverError::GuestError("Sp1: requesting proof failed".to_owned()))?;
+                .map_err(|e| {
+                    ProverError::GuestError(
+                        "Sp1: requesting proof failed: ".to_owned() + &e.to_string(),
+                    )
+                })?;
             if let Some(id_store) = id_store {
                 id_store
                     .store_id(

--- a/provers/sp1/driver/src/lib.rs
+++ b/provers/sp1/driver/src/lib.rs
@@ -123,9 +123,7 @@ impl Prover for Sp1Prover {
                 .request_proof(ELF, stdin, param.recursion.clone().into())
                 .await
                 .map_err(|e| {
-                    ProverError::GuestError(
-                        format!("Sp1: requesting proof failed: {e}")
-                    )
+                    ProverError::GuestError(format!("Sp1: requesting proof failed: {e}"))
                 })?;
             if let Some(id_store) = id_store {
                 id_store

--- a/provers/sp1/driver/src/lib.rs
+++ b/provers/sp1/driver/src/lib.rs
@@ -124,7 +124,7 @@ impl Prover for Sp1Prover {
                 .await
                 .map_err(|e| {
                     ProverError::GuestError(
-                        "Sp1: requesting proof failed: ".to_owned() + &e.to_string(),
+                        format!("Sp1: requesting proof failed: {e}")
                     )
                 })?;
             if let Some(id_store) = id_store {


### PR DESCRIPTION
Use error return instead of panic! to avoid unclean status which leads to endless WIP status back to client.
Probably need more refines with API CI test @petarvujovic98 .