### PR TITLE
fix(raiko): refine error return

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -182,5 +182,5 @@ if [[ -n $ZK ]]; then
         update_raiko_sgx_instance_id $RAIKO_CONF_BASE_CONFIG
         update_docker_chain_specs $RAIKO_CONF_CHAIN_SPECS
 
-        RUST_LOG=debug /opt/raiko/bin/raiko-host "$@"
+        /opt/raiko/bin/raiko-host "$@"
 fi

--- a/host/src/proof.rs
+++ b/host/src/proof.rs
@@ -178,7 +178,7 @@ impl ProofActor {
         manager
             .update_task_progress(key, status, proof.as_deref())
             .await
-            .map_err(|e| HostError::from(e))?;
+            .map_err(HostError::from)?;
         Ok(status)
     }
 }

--- a/host/src/proof.rs
+++ b/host/src/proof.rs
@@ -111,8 +111,8 @@ impl ProofActor {
                 }
                 result = Self::handle_message(proof_request, key.clone(), &opts, &chain_specs) => {
                     match result {
-                        Ok(()) => {
-                            info!("Host handling message");
+                        Ok(status) => {
+                            info!("Host handling message: {status:?}");
                         }
                         Err(error) => {
                             error!("Worker failed due to: {error:?}");
@@ -151,14 +151,14 @@ impl ProofActor {
         key: TaskDescriptor,
         opts: &Opts,
         chain_specs: &SupportedChainSpecs,
-    ) -> HostResult<()> {
+    ) -> HostResult<TaskStatus> {
         let mut manager = get_task_manager(&opts.clone().into());
 
         let status = manager.get_task_proving_status(&key).await?;
 
         if let Some(latest_status) = status.iter().last() {
             if !matches!(latest_status.0, TaskStatus::Registered) {
-                return Ok(());
+                return Ok(latest_status.0);
             }
         }
 
@@ -178,7 +178,8 @@ impl ProofActor {
         manager
             .update_task_progress(key, status, proof.as_deref())
             .await
-            .map_err(|e| e.into())
+            .map_err(|e| HostError::from(e))?;
+        Ok(status)
     }
 }
 

--- a/host/src/server/api/v2/mod.rs
+++ b/host/src/server/api/v2/mod.rs
@@ -84,8 +84,16 @@ impl From<Vec<u8>> for Status {
 
 impl From<TaskStatus> for Status {
     fn from(status: TaskStatus) -> Self {
-        Self::Ok {
-            data: ProofResponse::Status { status },
+        match status {
+            TaskStatus::Success
+            | TaskStatus::WorkInProgress
+            | TaskStatus::Registered => Self::Ok {
+                data: ProofResponse::Status { status },
+            },
+            _ => Self::Error {
+                error: "task_failed".to_string(),
+                message: format!("Task failed with status: {:?}", status),
+            },
         }
     }
 }

--- a/host/src/server/api/v2/mod.rs
+++ b/host/src/server/api/v2/mod.rs
@@ -85,9 +85,7 @@ impl From<Vec<u8>> for Status {
 impl From<TaskStatus> for Status {
     fn from(status: TaskStatus) -> Self {
         match status {
-            TaskStatus::Success
-            | TaskStatus::WorkInProgress
-            | TaskStatus::Registered => Self::Ok {
+            TaskStatus::Success | TaskStatus::WorkInProgress | TaskStatus::Registered => Self::Ok {
                 data: ProofResponse::Status { status },
             },
             _ => Self::Error {

--- a/host/src/server/api/v2/mod.rs
+++ b/host/src/server/api/v2/mod.rs
@@ -90,7 +90,7 @@ impl From<TaskStatus> for Status {
             },
             _ => Self::Error {
                 error: "task_failed".to_string(),
-                message: format!("Task failed with status: {:?}", status),
+                message: format!("Task failed with status: {status:?}"),
             },
         }
     }


### PR DESCRIPTION
hotfix for client error message handling. #376 

Currently UnspecifiedFailureReason seems a easy fit for merely db storage.
I change it to error return, next I think we need refine the error msg db as we need to give clear error message to client.