### PR TITLE
fix: add cgroup&mountinfo for docker env

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ WORKDIR /opt/raiko
 COPY . .
 RUN cargo build --release ${BUILD_FLAGS} --features "sgx" --features "docker_build"
 
-FROM gramineproject/gramine:1.6-jammy AS runtime
+FROM gramineproject/gramine:1.7-jammy AS runtime
 ENV DEBIAN_FRONTEND=noninteractive
 WORKDIR /opt/raiko
 

--- a/provers/sgx/config/sgx-guest.docker.manifest.template
+++ b/provers/sgx/config/sgx-guest.docker.manifest.template
@@ -18,6 +18,8 @@ fs.mounts = [
   { path = "{{ arch_libdir }}", uri = "file:{{ arch_libdir }}" },
   { path = "/usr/lib/ssl/certs/", uri = "file:/usr/lib/ssl/certs/" },
   { path = "/root/.config/raiko/config", uri = "file:/root/.config/raiko/config" },
+  { path = "/proc/self/mountinfo", uri = "file:/proc/self/mountinfo" },
+  { path = "/proc/self/cgroup", uri = "file:/proc/self/cgroup" },
   { path = "/root/.config/raiko/secrets", uri = "file:/root/.config/raiko/secrets", type = "encrypted", key_name = "_sgx_mrenclave" },
 ]
 sgx.allowed_files = [

--- a/provers/sgx/config/sgx-guest.docker.manifest.template
+++ b/provers/sgx/config/sgx-guest.docker.manifest.template
@@ -25,6 +25,9 @@ fs.mounts = [
 ]
 sgx.allowed_files = [
   "file:/root/.config/raiko/config",
+  "file:/proc/self/mountinfo",
+  "file:/proc/self/cgroup",
+  "file:/sys/fs/cgroup/",
 ]
 sgx.debug = false
 sgx.edmm_enable = {{ 'true' if env.get('EDMM', '1') == '1' else 'false' }}
@@ -37,7 +40,7 @@ sgx.trusted_files = [
   "file:/usr/lib/ssl/certs/",
   "file:sgx-guest",
 ]
-sgx.max_threads = 32
+sgx.max_threads = 512
 sgx.remote_attestation = "dcap"
 sys.enable_extra_runtime_domain_names_conf = true
 sys.insecure__allow_eventfd = true

--- a/provers/sgx/config/sgx-guest.docker.manifest.template
+++ b/provers/sgx/config/sgx-guest.docker.manifest.template
@@ -20,6 +20,7 @@ fs.mounts = [
   { path = "/root/.config/raiko/config", uri = "file:/root/.config/raiko/config" },
   { path = "/proc/self/mountinfo", uri = "file:/proc/self/mountinfo" },
   { path = "/proc/self/cgroup", uri = "file:/proc/self/cgroup" },
+  { path = "/sys/fs/cgroup/", uri = "file:/sys/fs/cgroup/" },
   { path = "/root/.config/raiko/secrets", uri = "file:/root/.config/raiko/secrets", type = "encrypted", key_name = "_sgx_mrenclave" },
 ]
 sgx.allowed_files = [


### PR DESCRIPTION
New added crates use the number of cores for thread pool, and needs to get the correct number from cgroup file