### PR TITLE
fix: incorrect state transition handling

### DIFF
--- a/lib/src/builder.rs
+++ b/lib/src/builder.rs
@@ -203,12 +203,12 @@ impl<DB: Database<Error = ProviderError> + DatabaseCommit + OptimisticDatabase>
             .into_iter()
             .map(|(address, bundle_account)| {
                 let mut account = Account {
-                    info: bundle_account.info.unwrap_or_default(),
+                    info: bundle_account.account_info().unwrap_or_default(),
                     storage: bundle_account.storage,
                     status: AccountStatus::default(),
                 };
                 account.mark_touch();
-                if bundle_account.status.was_destroyed() {
+                if bundle_account.info.is_none() {
                     account.mark_selfdestruct();
                 }
                 if bundle_account.original_info.is_none() {


### PR DESCRIPTION
# Background
We had an issue of block 380550 on our Mainnet when processing stress test. 
```console
2024-10-13T08:58:58.429218Z ERROR raiko_host::proof: There was an error with the core: There was an error with a guest prover: ProverError::GuestError `Condition failed: `self.input.block.state_ro
ot == state_root``
```
It told me, the state root of Raiko is different from Geth. My first impression is that there are differences in the modifications to Accounts during the execution of EVM. But...

# Root cause
I found that there was an unexpected `account-deleted` behavior in Raiko. 
<img width="938" alt="image" src="https://github.com/user-attachments/assets/0e677fe1-872b-49c4-8a0a-1cb38668116a">
And there are two transactions related to it in block 380550,
<img width="1474" alt="image" src="https://github.com/user-attachments/assets/1021d54a-1e47-4381-8ca9-5b1496222cf7">

|no | role |value |
|---|-----|------|
| 969| to | 0 ETH|
| 977| to | 0.0001 ETH|

Because the first one received zero ETH, so it's `nonce` and `balance` weren't changed. But, Revm marked it as Destroyed.
<img width="905" alt="image" src="https://github.com/user-attachments/assets/39933bf7-2609-4c4d-950c-9e0d24ae37a5">

<img width="832" alt="image" src="https://github.com/user-attachments/assets/c41dfb6f-2ea5-420a-83a8-2d6c9acf03be">
<p align="center">(LoadedEmptyEIP161 → Destroyed)</p>

And the second one let the status convert from Destroyed to DestroyedChanged
<img width="958" alt="image" src="https://github.com/user-attachments/assets/0a964b12-9e01-4807-974f-71caefbbdc81">

Revm has a function to tell people whether the Account is destroyed.
<img width="706" alt="image" src="https://github.com/user-attachments/assets/763e18c0-4eb2-4cf9-88f9-e782df879d7b">

Raiko considered it an account-deleted action. Actually, it can't. The DestroyedChanged maybe happened in our issue.

## Conclusion

The first transaction did not change the account information, no data needs to be stored, but it was marked as Destroyed by EIP161. The followed second transaction's status in the same block changed from Destroyed to DestroyedChanged. We simply assume that DestroyedChanged is what needs to be deleted.

# Debug journey
1. I thought the issue was due to EVM execution differences, so I compared the EVM execution traces of Geth and Reth to troubleshoot, but ultimately, they were identical.
2. I troubleshoot the issue by comparing state changes after each transaction execution in EVM. They were also the same.
3. Finally, I tracked the state changes in the Raiko's MemDB, and discovered the differences.

# Future plan
Replace it with Raiko-in-Reth project. Raiko added an extra state transformation. It may be more prone to bugs.

<img width="416" alt="image" src="https://github.com/user-attachments/assets/1bafcd0e-d3f1-4513-b2c9-28717bde8efc">
<p align="center">(Account status from Revm)</p>
<img width="712" alt="image" src="https://github.com/user-attachments/assets/01bc7607-7101-467f-9720-df71609d197f">
<p align="center">(Account status from Raiko)</p>
