### PR TITLE
chore: remove redundant and implicit From impl

### DIFF
--- a/core/src/preflight/mod.rs
+++ b/core/src/preflight/mod.rs
@@ -87,12 +87,13 @@ pub async fn preflight<BDP: BlockDataProvider>(
     let parent_block_number = parent_header.number;
 
     // Create the guest input
-    let input = GuestInput::from((
-        block.clone(),
+    let input = GuestInput {
+        block,
         parent_header,
-        taiko_chain_spec.clone(),
-        taiko_guest_input,
-    ));
+        chain_spec: taiko_chain_spec.clone(),
+        taiko: taiko_guest_input,
+        ..Default::default()
+    };
 
     // Create the block builder, run the transactions and extract the DB
     let provider_db = ProviderDb::new(provider, taiko_chain_spec, parent_block_number).await?;

--- a/host/src/lib.rs
+++ b/host/src/lib.rs
@@ -167,24 +167,6 @@ pub enum Message {
     Aggregate(AggregationOnlyRequest),
 }
 
-impl From<&ProofRequest> for Message {
-    fn from(value: &ProofRequest) -> Self {
-        Self::Task(value.clone())
-    }
-}
-
-impl From<&ProofTaskDescriptor> for Message {
-    fn from(value: &ProofTaskDescriptor) -> Self {
-        Self::Cancel(value.clone())
-    }
-}
-
-impl From<AggregationOnlyRequest> for Message {
-    fn from(value: AggregationOnlyRequest) -> Self {
-        Self::Aggregate(value)
-    }
-}
-
 impl ProverState {
     pub fn init() -> HostResult<Self> {
         // Read the command line arguments;

--- a/host/src/server/api/v2/proof/cancel.rs
+++ b/host/src/server/api/v2/proof/cancel.rs
@@ -49,7 +49,9 @@ async fn cancel_handler(
         proof_request.prover.clone().to_string(),
     ));
 
-    prover_state.task_channel.try_send(Message::from(&key))?;
+    prover_state
+        .task_channel
+        .try_send(Message::Cancel(key.clone()))?;
 
     let mut manager = prover_state.task_manager();
 

--- a/host/src/server/api/v2/proof/mod.rs
+++ b/host/src/server/api/v2/proof/mod.rs
@@ -81,7 +81,7 @@ async fn proof_handler(
 
                     prover_state
                         .task_channel
-                        .try_send(Message::from(&proof_request))?;
+                        .try_send(Message::Task(proof_request))?;
 
                     Ok(TaskStatus::Registered.into())
                 }
@@ -100,7 +100,7 @@ async fn proof_handler(
 
             prover_state
                 .task_channel
-                .try_send(Message::from(&proof_request))?;
+                .try_send(Message::Task(proof_request))?;
 
             Ok(TaskStatus::Registered.into())
         }

--- a/host/src/server/api/v3/proof/aggregate.rs
+++ b/host/src/server/api/v3/proof/aggregate.rs
@@ -64,7 +64,7 @@ async fn aggregation_handler(
 
         prover_state
             .task_channel
-            .try_send(Message::from(aggregation_request.clone()))?;
+            .try_send(Message::Aggregate(aggregation_request))?;
         return Ok(Status::from(TaskStatus::Registered));
     };
 
@@ -84,7 +84,7 @@ async fn aggregation_handler(
 
             prover_state
                 .task_channel
-                .try_send(Message::from(aggregation_request))?;
+                .try_send(Message::Aggregate(aggregation_request))?;
 
             Ok(Status::from(TaskStatus::Registered))
         }

--- a/host/src/server/api/v3/proof/cancel.rs
+++ b/host/src/server/api/v3/proof/cancel.rs
@@ -52,7 +52,9 @@ async fn cancel_handler(
             proof_request.prover.clone().to_string(),
         ));
 
-        prover_state.task_channel.try_send(Message::from(&key))?;
+        prover_state
+            .task_channel
+            .try_send(Message::Cancel(key.clone()))?;
 
         let mut manager = prover_state.task_manager();
 

--- a/host/src/server/api/v3/proof/mod.rs
+++ b/host/src/server/api/v3/proof/mod.rs
@@ -98,7 +98,7 @@ async fn proof_handler(
                     manager
                         .update_task_progress(key.clone(), TaskStatus::Registered, None)
                         .await?;
-                    prover_state.task_channel.try_send(Message::from(req))?;
+                    prover_state.task_channel.try_send(Message::Task(req.to_owned()))?;
 
                     is_registered = true;
                     is_success = false;
@@ -116,7 +116,9 @@ async fn proof_handler(
             // If there are no tasks with provided config, create a new one.
             manager.enqueue_task(key).await?;
 
-            prover_state.task_channel.try_send(Message::from(req))?;
+            prover_state
+                .task_channel
+                .try_send(Message::Task(req.to_owned()))?;
             is_registered = true;
             continue;
         };
@@ -170,7 +172,7 @@ async fn proof_handler(
                         .await?;
                     prover_state
                         .task_channel
-                        .try_send(Message::from(aggregation_request))?;
+                        .try_send(Message::Aggregate(aggregation_request))?;
                     Ok(Status::from(TaskStatus::Registered))
                 }
                 // If the task has succeeded, return the proof.
@@ -191,7 +193,7 @@ async fn proof_handler(
 
             prover_state
                 .task_channel
-                .try_send(Message::from(aggregation_request.clone()))?;
+                .try_send(Message::Aggregate(aggregation_request))?;
             Ok(Status::from(TaskStatus::Registered))
         }
     } else {

--- a/lib/src/input.rs
+++ b/lib/src/input.rs
@@ -79,20 +79,6 @@ pub struct ZkAggregationGuestInput {
     pub block_inputs: Vec<B256>,
 }
 
-impl From<(Block, Header, ChainSpec, TaikoGuestInput)> for GuestInput {
-    fn from(
-        (block, parent_header, chain_spec, taiko): (Block, Header, ChainSpec, TaikoGuestInput),
-    ) -> Self {
-        Self {
-            block,
-            chain_spec,
-            taiko,
-            parent_header,
-            ..Self::default()
-        }
-    }
-}
-
 #[derive(Clone, Debug, Default, Serialize, Deserialize)]
 
 pub enum BlockProposedFork {


### PR DESCRIPTION
This PR removes several implicit From implementations, which made type transformations implicit and not easy to understand without providing any benefits.