### PR TITLE
feat: union proof type relevant stuff

### DIFF
--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -91,7 +91,7 @@ impl Raiko {
 
                 Ok(GuestOutput {
                     header: header.clone(),
-                    hash: ProtocolInstance::new(input, &header, self.request.proof_type.into())?
+                    hash: ProtocolInstance::new(input, &header, self.request.proof_type)?
                         .instance_hash(),
                 })
             }

--- a/core/src/prover.rs
+++ b/core/src/prover.rs
@@ -1,8 +1,8 @@
 use std::path::Path;
 
 use raiko_lib::{
-    consts::VerifierType,
     input::{GuestInput, GuestOutput},
+    proof_type::ProofType,
     protocol_instance::ProtocolInstance,
     prover::{IdStore, IdWrite, Proof, ProofKey, Prover, ProverConfig, ProverError, ProverResult},
 };
@@ -49,7 +49,7 @@ impl Prover for NativeProver {
 
         trace!("Running the native prover for input {input:?}");
 
-        let pi = ProtocolInstance::new(&input, &output.header, VerifierType::None)
+        let pi = ProtocolInstance::new(&input, &output.header, ProofType::Native)
             .map_err(|e| ProverError::GuestError(e.to_string()))?;
         if pi.instance_hash() != output.hash {
             return Err(ProverError::GuestError(

--- a/lib/src/proof_type.rs
+++ b/lib/src/proof_type.rs
@@ -9,18 +9,22 @@ pub enum ProofType {
     /// # Native
     ///
     /// This builds the block the same way the node does and then runs the result.
+    #[serde(alias = "NATIVE")]
     Native = 0u8,
     /// # Sp1
     ///
     /// Uses the SP1 prover to build the block.
+    #[serde(alias = "SP1")]
     Sp1 = 1u8,
     /// # Sgx
     ///
     /// Builds the block on a SGX supported CPU to create a proof.
+    #[serde(alias = "SGX")]
     Sgx = 2u8,
     /// # Risc0
     ///
     /// Uses the RISC0 prover to build the block.
+    #[serde(alias = "RISC0")]
     Risc0 = 3u8,
 }
 

--- a/lib/src/proof_type.rs
+++ b/lib/src/proof_type.rs
@@ -3,25 +3,25 @@ use serde::{Deserialize, Serialize};
 #[derive(
     PartialEq, Eq, PartialOrd, Ord, Clone, Debug, Default, Deserialize, Serialize, Hash, Copy,
 )]
-/// Available proof types.
+#[repr(u8)]
 pub enum ProofType {
     #[default]
     /// # Native
     ///
     /// This builds the block the same way the node does and then runs the result.
-    Native,
+    Native = 0u8,
     /// # Sp1
     ///
     /// Uses the SP1 prover to build the block.
-    Sp1,
+    Sp1 = 1u8,
     /// # Sgx
     ///
     /// Builds the block on a SGX supported CPU to create a proof.
-    Sgx,
+    Sgx = 2u8,
     /// # Risc0
     ///
     /// Uses the RISC0 prover to build the block.
-    Risc0,
+    Risc0 = 3u8,
 }
 
 impl std::fmt::Display for ProofType {

--- a/lib/src/protocol_instance.rs
+++ b/lib/src/protocol_instance.rs
@@ -6,7 +6,7 @@ use reth_primitives::Header;
 #[cfg(not(feature = "std"))]
 use crate::no_std::*;
 use crate::{
-    consts::{SupportedChainSpecs, VerifierType},
+    consts::SupportedChainSpecs,
     input::{
         ontake::{BlockMetadataV2, BlockProposedV2},
         BlobProofType, BlockMetadata, BlockProposed, BlockProposedFork, EthDeposit, GuestInput,
@@ -16,6 +16,7 @@ use crate::{
         eip4844::{self, commitment_to_version_hash},
         keccak::keccak,
     },
+    proof_type::ProofType,
     CycleTracker,
 };
 use reth_evm_ethereum::taiko::ANCHOR_GAS_LIMIT;
@@ -138,7 +139,7 @@ pub struct ProtocolInstance {
 }
 
 impl ProtocolInstance {
-    pub fn new(input: &GuestInput, header: &Header, proof_type: VerifierType) -> Result<Self> {
+    pub fn new(input: &GuestInput, header: &Header, proof_type: ProofType) -> Result<Self> {
         let blob_used = input.taiko.block_proposed.blob_used();
         // If blob is used, tx_list_hash is the commitment to the blob
         // and we need to verify the blob hash matches the blob data.
@@ -307,16 +308,16 @@ impl ProtocolInstance {
 
 // Make sure the verifier supports the blob proof type
 fn get_blob_proof_type(
-    proof_type: VerifierType,
+    proof_type: ProofType,
     blob_proof_type_hint: BlobProofType,
 ) -> BlobProofType {
     // Enforce different blob proof type for different provers
     // due to performance considerations
     match proof_type {
-        VerifierType::None => blob_proof_type_hint,
-        VerifierType::SGX => BlobProofType::KzgVersionedHash,
-        VerifierType::SP1 => BlobProofType::ProofOfEquivalence,
-        VerifierType::RISC0 => BlobProofType::ProofOfEquivalence,
+        ProofType::Native => blob_proof_type_hint,
+        ProofType::Sgx => BlobProofType::KzgVersionedHash,
+        ProofType::Sp1 => BlobProofType::ProofOfEquivalence,
+        ProofType::Risc0 => BlobProofType::ProofOfEquivalence,
     }
 }
 

--- a/provers/risc0/driver/src/lib.rs
+++ b/provers/risc0/driver/src/lib.rs
@@ -14,6 +14,7 @@ use raiko_lib::{
         AggregationGuestInput, AggregationGuestOutput, GuestInput, GuestOutput,
         ZkAggregationGuestInput,
     },
+    proof_type::ProofType,
     prover::{IdStore, IdWrite, Proof, ProofKey, Prover, ProverConfig, ProverError, ProverResult},
 };
 use risc0_zkvm::{
@@ -60,8 +61,6 @@ impl From<Risc0Response> for Proof {
 
 pub struct Risc0Prover;
 
-const RISC0_PROVER_CODE: u8 = 3;
-
 impl Prover for Risc0Prover {
     async fn run(
         input: GuestInput,
@@ -75,7 +74,7 @@ impl Prover for Risc0Prover {
             input.chain_spec.chain_id,
             input.block.header.number,
             output.hash,
-            RISC0_PROVER_CODE,
+            ProofType::Risc0 as u8,
         );
 
         debug!("elf code length: {}", RISC0_GUEST_ELF.len());

--- a/provers/risc0/guest/src/main.rs
+++ b/provers/risc0/guest/src/main.rs
@@ -1,12 +1,12 @@
 #![no_main]
 harness::entrypoint!(main, tests, zk_op::tests);
 use raiko_lib::{
-    builder::calculate_block_header, consts::VerifierType, input::GuestInput,
+    builder::calculate_block_header, input::GuestInput, proof_type::ProofType,
     protocol_instance::ProtocolInstance,
 };
 use revm_precompile::zk_op::ZkOperation;
-use zk_op::Risc0Operator;
 use risc0_zkvm::guest::env;
+use zk_op::Risc0Operator;
 
 pub mod mem;
 
@@ -21,7 +21,7 @@ fn main() {
         .expect("Failed to set ZkvmOperations");
 
     let header = calculate_block_header(&input);
-    let pi = ProtocolInstance::new(&input, &header, VerifierType::RISC0)
+    let pi = ProtocolInstance::new(&input, &header, ProofType::Risc0)
         .unwrap()
         .instance_hash();
 

--- a/provers/sgx/guest/src/one_shot.rs
+++ b/provers/sgx/guest/src/one_shot.rs
@@ -9,9 +9,9 @@ use anyhow::{anyhow, bail, Context, Error, Result};
 use base64_serde::base64_serde_type;
 use raiko_lib::{
     builder::calculate_block_header,
-    consts::VerifierType,
     input::{GuestInput, RawAggregationGuestInput},
     primitives::{keccak, Address, B256},
+    proof_type::ProofType,
     protocol_instance::{aggregation_output_combine, ProtocolInstance},
 };
 use secp256k1::{Keypair, SecretKey};
@@ -134,7 +134,7 @@ pub async fn one_shot(global_opts: GlobalOpts, args: OneShotArgs) -> Result<()> 
     // Process the block
     let header = calculate_block_header(&input);
     // Calculate the public input hash
-    let pi = ProtocolInstance::new(&input, &header, VerifierType::SGX)?.sgx_instance(new_instance);
+    let pi = ProtocolInstance::new(&input, &header, ProofType::Sgx)?.sgx_instance(new_instance);
     let pi_hash = pi.instance_hash();
 
     println!(

--- a/provers/sgx/setup/src/setup_bootstrap.rs
+++ b/provers/sgx/setup/src/setup_bootstrap.rs
@@ -8,7 +8,7 @@ use std::{
 
 use anyhow::{anyhow, Context, Result};
 use file_lock::{FileLock, FileOptions};
-use raiko_lib::consts::{SupportedChainSpecs, VerifierType};
+use raiko_lib::{consts::SupportedChainSpecs, proof_type::ProofType};
 use serde_json::{Number, Value};
 use sgx_prover::{
     bootstrap, check_bootstrap, get_instance_id, register_sgx_instance, remove_instance_id,
@@ -69,8 +69,8 @@ pub(crate) async fn setup_bootstrap(
         // clean check file
         remove_instance_id(&config_dir)?;
         let bootstrap_proof = bootstrap(secret_dir, gramine_cmd()).await?;
-        let verifier_address = taiko_chain_spec
-            .get_fork_verifier_address(bootstrap_args.block_num, VerifierType::SGX)?;
+        let verifier_address =
+            taiko_chain_spec.get_fork_verifier_address(bootstrap_args.block_num, ProofType::Sgx)?;
         let register_id = register_sgx_instance(
             &bootstrap_proof.quote,
             &l1_chain_spec.rpc,

--- a/provers/sp1/driver/src/lib.rs
+++ b/provers/sp1/driver/src/lib.rs
@@ -6,6 +6,7 @@ use raiko_lib::{
         AggregationGuestInput, AggregationGuestOutput, GuestInput, GuestOutput,
         ZkAggregationGuestInput,
     },
+    proof_type::ProofType,
     prover::{IdStore, IdWrite, Proof, ProofKey, Prover, ProverConfig, ProverError, ProverResult},
     Measurement,
 };
@@ -27,7 +28,6 @@ use proof_verify::remote_contract_verify::verify_sol_by_contract_call;
 
 pub const ELF: &[u8] = include_bytes!("../../guest/elf/sp1-guest");
 pub const AGGREGATION_ELF: &[u8] = include_bytes!("../../guest/elf/sp1-aggregation");
-const SP1_PROVER_CODE: u8 = 1;
 
 #[serde_as]
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -156,7 +156,7 @@ impl Prover for Sp1Prover {
                             input.chain_spec.chain_id,
                             input.block.header.number,
                             output.hash,
-                            SP1_PROVER_CODE,
+                            ProofType::Sp1 as u8,
                         ),
                         proof_id.clone(),
                     )

--- a/provers/sp1/driver/src/verifier.rs
+++ b/provers/sp1/driver/src/verifier.rs
@@ -3,6 +3,7 @@ use alloy_primitives::B256;
 use raiko_lib::builder::calculate_block_header;
 use raiko_lib::consts::VerifierType;
 use raiko_lib::input::{BlobProofType, GuestInput, GuestOutput};
+use raiko_lib::proof_type::ProofType;
 use raiko_lib::protocol_instance::ProtocolInstance;
 use raiko_lib::prover::Prover;
 use raiko_lib::Measurement;
@@ -39,7 +40,7 @@ async fn main() {
 
     let header = calculate_block_header(&input);
 
-    let _pi = ProtocolInstance::new(&input, &header, VerifierType::SP1)
+    let _pi = ProtocolInstance::new(&input, &header, ProofType::SP1)
         .unwrap()
         .instance_hash();
 

--- a/provers/sp1/driver/src/verifier.rs
+++ b/provers/sp1/driver/src/verifier.rs
@@ -1,7 +1,6 @@
 #![cfg(feature = "enable")]
 use alloy_primitives::B256;
 use raiko_lib::builder::calculate_block_header;
-use raiko_lib::consts::VerifierType;
 use raiko_lib::input::{BlobProofType, GuestInput, GuestOutput};
 use raiko_lib::proof_type::ProofType;
 use raiko_lib::protocol_instance::ProtocolInstance;

--- a/provers/sp1/guest/src/main.rs
+++ b/provers/sp1/guest/src/main.rs
@@ -2,7 +2,7 @@
 harness::entrypoint!(main, tests, zk_op::tests);
 
 use raiko_lib::{
-    builder::calculate_block_header, consts::VerifierType, input::GuestInput,
+    builder::calculate_block_header, input::GuestInput, proof_type::ProofType,
     protocol_instance::ProtocolInstance, CycleTracker,
 };
 
@@ -20,7 +20,7 @@ pub fn main() {
     ct.end();
 
     ct = CycleTracker::start("ProtocolInstance");
-    let pi = ProtocolInstance::new(&input, &header, VerifierType::SP1)
+    let pi = ProtocolInstance::new(&input, &header, ProofType::Sp1)
         .unwrap()
         .instance_hash();
     ct.end();


### PR DESCRIPTION
This PR make the follow-up changes of https://github.com/taikoxyz/raiko/pull/421#issue-2690366478 



> 2. Merge `Proof System ID` into `ProofType`, to eliminate redundant definitions and simplify the management of proof types for taskdb
> 
>     - [Proof System ID](https://github.com/keroro520/raiko/blob/7b374f137decffea8f92d8c2ab15c0e3a423939f/taskdb/src/adv_sqlite.rs#L57-L62), also known as "prover code"
>     - [Proof System ID `RISC0_PROVER_CODE = 3`](https://github.com/keroro520/raiko/blob/7b374f137decffea8f92d8c2ab15c0e3a423939f/provers/risc0/driver/src/lib.rs#L63)
>     - [Proof System ID `SP1_PROVER_CODE = 1`](https://github.com/keroro520/raiko/blob/7b374f137decffea8f92d8c2ab15c0e3a423939f/provers/sp1/driver/src/lib.rs#L30)
> 
> 3. Merge `VerifierType` into `ProofType`.
> 
>     - [`VerifierType`](https://github.com/keroro520/raiko/blob/7b374f137decffea8f92d8c2ab15c0e3a423939f/lib/src/consts.rs#L134)
