### PR TITLE
fix(raiko): fix sp1 aggregation verification error

### DIFF
--- a/provers/sp1/driver/src/lib.rs
+++ b/provers/sp1/driver/src/lib.rs
@@ -266,8 +266,9 @@ impl Prover for Sp1Prover {
             block_inputs,
         };
         info!(
-            "Aggregating {:?} proofs with input: {aggregation_input:?}",
+            "Collect {:?} proofs aggregation pi inputs: {:?}",
             input.proofs.len(),
+            aggregation_input.block_inputs
         );
 
         let mut stdin = SP1Stdin::new();
@@ -316,7 +317,7 @@ impl Prover for Sp1Prover {
             let aggregation_pi = prove_result.clone().borrow_mut().public_values.raw();
             let fixture = RaikoProofFixture {
                 vkey: vk.bytes32().to_string(),
-                public_values: reth_primitives::hex::encode_prefixed(aggregation_pi),
+                public_values: aggregation_pi,
                 proof: proof_bytes.clone(),
             };
 


### PR DESCRIPTION
Fix off-chain sp1 aggregation proof verification error:
```
"2024-12-12T12:03:37.672895Z ERROR sp1_driver::proof_verify::remote_contract_verify: SP1 proof verification failed: Err(TransportError(ErrorResp(ErrorPayload { code: 3, message: "execution reverted", data: Some(RawValue("0x09bde339")) })))!"
```