### PR TITLE
fix(raiko): avoid duplicate image uploads

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8772,6 +8772,7 @@ dependencies = [
  "cargo_metadata 0.18.1",
  "cfg-if",
  "chrono",
+ "dashmap",
  "dotenv",
  "once_cell",
  "raiko-lib",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -140,6 +140,7 @@ tokio-util = { version = "0.7.11" }
 reqwest = { version = "0.11.22", features = ["json"] }
 url = "2.5.0"
 async-trait = "0.1.80"
+dashmap = "5.5.3"
 
 # crypto
 kzg = { package = "rust-kzg-zkcrypto", git = "https://github.com/ceciliaz030/rust-kzg.git", branch = "brecht/sp1-patch", default-features = false }

--- a/provers/risc0/driver/src/bonsai.rs
+++ b/provers/risc0/driver/src/bonsai.rs
@@ -6,6 +6,7 @@ use crate::{
 use alloy_primitives::B256;
 use bonsai_sdk::blocking::{Client, SessionId};
 use log::{debug, error, info, warn};
+use once_cell::sync::OnceCell;
 use raiko_lib::{
     primitives::keccak::keccak,
     prover::{IdWrite, ProofKey, ProverError, ProverResult},
@@ -19,6 +20,7 @@ use std::{
     fmt::Debug,
     fs,
     path::{Path, PathBuf},
+    sync::Arc,
 };
 use tokio::time::{sleep as tokio_async_sleep, Duration};
 
@@ -263,6 +265,30 @@ pub async fn cancel_proof(uuid: String) -> anyhow::Result<()> {
     Ok(())
 }
 
+struct BonsaiClient {
+    pub(crate) client: Arc<Client>,
+}
+
+impl BonsaiClient {
+    pub fn instance(
+        encoded_image_id: &String,
+        elf: Vec<u8>,
+    ) -> Result<&'static BonsaiClient, BonsaiExecutionError> {
+        static INSTANCE: OnceCell<BonsaiClient> = OnceCell::new();
+
+        Ok(INSTANCE
+            .get_or_try_init(|| {
+                let client = Client::from_env(risc0_zkvm::VERSION)?;
+                client.upload_img(&encoded_image_id, elf)?;
+
+                Ok(BonsaiClient {
+                    client: Arc::new(client),
+                })
+            })
+            .map_err(|e| BonsaiExecutionError::SdkFailure(e))?)
+    }
+}
+
 pub async fn prove_bonsai<O: Eq + Debug + DeserializeOwned>(
     encoded_input: Vec<u32>,
     elf: &[u8],
@@ -279,8 +305,9 @@ pub async fn prove_bonsai<O: Eq + Debug + DeserializeOwned>(
     // Prepare input data
     let input_data = bytemuck::cast_slice(&encoded_input).to_vec();
 
-    let client = Client::from_env(risc0_zkvm::VERSION)?;
-    client.upload_img(&encoded_image_id, elf.to_vec())?;
+    let client = BonsaiClient::instance(&encoded_image_id, elf.to_vec())?
+        .client
+        .clone();
     // upload input
     let input_id = client.upload_input(input_data.clone())?;
 

--- a/provers/sp1/driver/Cargo.toml
+++ b/provers/sp1/driver/Cargo.toml
@@ -35,7 +35,7 @@ bincode = { workspace = true }
 reth-primitives = { workspace = true }
 tokio = { workspace = true, optional = true }
 tracing = { workspace = true, optional = true }
-
+dashmap = { workspace = true }
 
 [build-dependencies]
 sp1-helper = { workspace = true, optional = true }


### PR DESCRIPTION
The block proof ELF is approximately 8 MB, and is being uploaded every time. Using an initialization-once approach to avoid redundant uploads