### PR TITLE
feat(host): impl API "/admin/pause"

### DIFF
--- a/host/src/interfaces.rs
+++ b/host/src/interfaces.rs
@@ -72,6 +72,10 @@ pub enum HostError {
     /// For task manager errors.
     #[error("There was an error with the task manager: {0}")]
     TaskManager(#[from] TaskManagerError),
+
+    /// For system paused state.
+    #[error("System is paused")]
+    SystemPaused,
 }
 
 impl IntoResponse for HostError {
@@ -91,6 +95,7 @@ impl IntoResponse for HostError {
             HostError::Anyhow(e) => ("anyhow_error", e.to_string()),
             HostError::HandleDropped => ("handle_dropped", "".to_owned()),
             HostError::CapacityFull => ("capacity_full", "".to_owned()),
+            HostError::SystemPaused => ("system_paused", "".to_owned()),
         };
         let status = Status::Error {
             error: error.to_owned(),
@@ -130,6 +135,7 @@ impl From<HostError> for TaskStatus {
             HostError::RPC(e) => TaskStatus::NetworkFailure(e.to_string()),
             HostError::Guest(e) => TaskStatus::GuestProverFailure(e.to_string()),
             HostError::TaskManager(e) => TaskStatus::TaskDbCorruption(e.to_string()),
+            HostError::SystemPaused => TaskStatus::SystemPaused,
         }
     }
 }
@@ -151,6 +157,7 @@ impl From<&HostError> for TaskStatus {
             HostError::RPC(e) => TaskStatus::NetworkFailure(e.to_string()),
             HostError::Guest(e) => TaskStatus::GuestProverFailure(e.to_string()),
             HostError::TaskManager(e) => TaskStatus::TaskDbCorruption(e.to_string()),
+            HostError::SystemPaused => TaskStatus::SystemPaused,
         }
     }
 }

--- a/host/src/server/api/admin.rs
+++ b/host/src/server/api/admin.rs
@@ -1,0 +1,114 @@
+use axum::{extract::State, routing::post, Router};
+
+use crate::{interfaces::HostResult, ProverState};
+
+pub fn create_router() -> Router<ProverState> {
+    Router::new()
+        .route("/admin/pause", post(pause))
+        .route("/admin/unpause", post(unpause))
+}
+
+async fn pause(State(state): State<ProverState>) -> HostResult<&'static str> {
+    state.set_pause(true).await?;
+    Ok("System paused successfully")
+}
+
+async fn unpause(State(state): State<ProverState>) -> HostResult<&'static str> {
+    state.set_pause(false).await?;
+    Ok("System unpaused successfully")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::{
+        body::Body,
+        http::{Request, StatusCode},
+    };
+    use clap::Parser;
+    use std::path::PathBuf;
+    use tower::ServiceExt;
+
+    #[tokio::test]
+    async fn test_pause() {
+        let opts = {
+            let mut opts = crate::Opts::parse();
+            opts.config_path = PathBuf::from("../host/config/config.json");
+            opts.merge_from_file().unwrap();
+            opts
+        };
+        let state = ProverState::init_with_opts(opts).unwrap();
+        let app = Router::new()
+            .route("/admin/pause", post(pause))
+            .with_state(state.clone());
+
+        let request = Request::builder()
+            .method("POST")
+            .uri("/admin/pause")
+            .body(Body::empty())
+            .unwrap();
+
+        let response = app.oneshot(request).await.unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        assert!(state.is_paused());
+    }
+
+    #[tokio::test]
+    async fn test_pause_when_already_paused() {
+        let opts = {
+            let mut opts = crate::Opts::parse();
+            opts.config_path = PathBuf::from("../host/config/config.json");
+            opts.merge_from_file().unwrap();
+            opts
+        };
+        let state = ProverState::init_with_opts(opts).unwrap();
+
+        state.set_pause(true).await.unwrap();
+
+        let app = Router::new()
+            .route("/admin/pause", post(pause))
+            .with_state(state.clone());
+
+        let request = Request::builder()
+            .method("POST")
+            .uri("/admin/pause")
+            .body(Body::empty())
+            .unwrap();
+
+        let response = app.oneshot(request).await.unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        assert!(state.is_paused());
+    }
+
+    #[tokio::test]
+    async fn test_unpause() {
+        let opts = {
+            let mut opts = crate::Opts::parse();
+            opts.config_path = PathBuf::from("../host/config/config.json");
+            opts.merge_from_file().unwrap();
+            opts
+        };
+        let state = ProverState::init_with_opts(opts).unwrap();
+
+        // Set initial paused state
+        state.set_pause(true).await.unwrap();
+        assert!(state.is_paused());
+
+        let app = Router::new()
+            .route("/admin/unpause", post(unpause))
+            .with_state(state.clone());
+
+        let request = Request::builder()
+            .method("POST")
+            .uri("/admin/unpause")
+            .body(Body::empty())
+            .unwrap();
+
+        let response = app.oneshot(request).await.unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        assert!(!state.is_paused());
+    }
+}

--- a/host/src/server/api/mod.rs
+++ b/host/src/server/api/mod.rs
@@ -16,6 +16,8 @@ use tower_http::{
 
 use crate::ProverState;
 
+pub mod admin;
+pub mod util;
 pub mod v1;
 pub mod v2;
 pub mod v3;
@@ -39,12 +41,14 @@ pub fn create_router(concurrency_limit: usize, jwt_secret: Option<&str>) -> Rout
     let v1_api = v1::create_router(concurrency_limit);
     let v2_api = v2::create_router();
     let v3_api = v3::create_router();
+    let admin_api = admin::create_router();
 
     let router = Router::new()
         .nest("/v1", v1_api)
         .nest("/v2", v2_api)
         .nest("/v3", v3_api.clone())
         .merge(v3_api)
+        .nest("/admin", admin_api)
         .layer(middleware)
         .layer(middleware::from_fn(check_max_body_size))
         .layer(trace)

--- a/host/src/server/api/util.rs
+++ b/host/src/server/api/util.rs
@@ -1,0 +1,12 @@
+use crate::{
+    interfaces::{HostError, HostResult},
+    ProverState,
+};
+
+/// Ensure that the system is not paused, otherwise return an error.
+pub fn ensure_not_paused(prover_state: &ProverState) -> HostResult<()> {
+    if prover_state.is_paused() {
+        return Err(HostError::SystemPaused);
+    }
+    Ok(())
+}

--- a/host/src/server/api/v1/proof.rs
+++ b/host/src/server/api/v1/proof.rs
@@ -8,7 +8,7 @@ use crate::{
     interfaces::HostResult,
     metrics::{dec_current_req, inc_current_req, inc_guest_req_count, inc_host_req_count},
     proof::handle_proof,
-    server::api::v1::Status,
+    server::api::{util::ensure_not_paused, v1::Status},
     ProverState,
 };
 
@@ -35,6 +35,9 @@ async fn proof_handler(
     Json(req): Json<Value>,
 ) -> HostResult<Json<Status>> {
     inc_current_req();
+
+    ensure_not_paused(&prover_state)?;
+
     // Override the existing proof request config from the config file and command line
     // options with the request from the client.
     let mut config = prover_state.request_config();

--- a/host/src/server/api/v2/proof/mod.rs
+++ b/host/src/server/api/v2/proof/mod.rs
@@ -7,7 +7,7 @@ use utoipa::OpenApi;
 use crate::{
     interfaces::HostResult,
     metrics::{inc_current_req, inc_guest_req_count, inc_host_req_count},
-    server::api::v2::Status,
+    server::api::{util::ensure_not_paused, v2::Status},
     Message, ProverState,
 };
 
@@ -37,6 +37,9 @@ async fn proof_handler(
     Json(req): Json<Value>,
 ) -> HostResult<Status> {
     inc_current_req();
+
+    ensure_not_paused(&prover_state)?;
+
     // Override the existing proof request config from the config file and command line
     // options with the request from the client.
     let mut config = prover_state.request_config();

--- a/host/src/server/api/v3/proof/aggregate/cancel.rs
+++ b/host/src/server/api/v3/proof/aggregate/cancel.rs
@@ -65,7 +65,8 @@ async fn cancel_handler(
         | TaskStatus::GuestProverFailure(_)
         | TaskStatus::InvalidOrUnsupportedBlock
         | TaskStatus::UnspecifiedFailureReason
-        | TaskStatus::TaskDbCorruption(_) => {
+        | TaskStatus::TaskDbCorruption(_)
+        | TaskStatus::SystemPaused => {
             should_signal_cancel = true;
             CancelStatus::Error {
                 error: "Task already completed".to_string(),

--- a/taskdb/src/lib.rs
+++ b/taskdb/src/lib.rs
@@ -71,6 +71,7 @@ pub enum TaskStatus {
     GuestProverFailure(String),
     UnspecifiedFailureReason,
     TaskDbCorruption(String),
+    SystemPaused,
 }
 
 impl From<TaskStatus> for i32 {
@@ -92,6 +93,7 @@ impl From<TaskStatus> for i32 {
             TaskStatus::GuestProverFailure(_) => -7000,
             TaskStatus::UnspecifiedFailureReason => -8000,
             TaskStatus::TaskDbCorruption(_) => -9000,
+            TaskStatus::SystemPaused => -10000,
         }
     }
 }
@@ -115,6 +117,7 @@ impl From<i32> for TaskStatus {
             -7000 => TaskStatus::GuestProverFailure("".to_string()),
             -8000 => TaskStatus::UnspecifiedFailureReason,
             -9000 => TaskStatus::TaskDbCorruption("".to_string()),
+            -10000 => TaskStatus::SystemPaused,
             _ => TaskStatus::UnspecifiedFailureReason,
         }
     }


### PR DESCRIPTION
Add HTTP API "/admin/pause".

Clear pending tasks and cancel all running tasks and aggregation tasks when "/admin/pause" called.

- [x] Add HTTP endpoint "/admin/pause" and "/admin/unpause"
- [x] Add a pause flag `Prover.pause_flag`
- [x] Handle pause message inside ProofActor
- [x] Add tests covered HTTP endpoint "/admin/pause"
- [x] Add tests covered `ProofActor.handle_system_pause()`
- [x] Reject request if pause flag is true

---

TODOs in the future:

- [Cancelled tasks should be removed from running_tasks/aggregate_tasks](https://github.com/taikoxyz/raiko/pull/440/files#diff-527386fe2e859ee858305b0298d486712a574b764b108804f527fc1cf54b0a97R634-R635)
- [make sure all tasks are saved to database, including pending tasks.](https://github.com/taikoxyz/raiko/pull/440/files#diff-527386fe2e859ee858305b0298d486712a574b764b108804f527fc1cf54b0a97R471)
- https://github.com/taikoxyz/raiko/pull/440#discussion_r1897093468                 
- WorkingInProgress task can not be cancelled, actually.
- API for query task
- https://github.com/taikoxyz/raiko/pull/440#discussion_r1897219496