### PR TITLE
feat(Dockerfile.pccs): bump base image to ubuntu 24.04

### DIFF
--- a/Dockerfile.pccs
+++ b/Dockerfile.pccs
@@ -1,7 +1,7 @@
 # https://raw.githubusercontent.com/intel/SGXDataCenterAttestationPrimitives/master/QuoteGeneration/pccs/container/Dockerfile
 
 # Use multi-stage builds to reduce final image size
-FROM ubuntu:23.04 AS builder
+FROM ubuntu:24.04 AS builder
 
 # Define arguments used across multiple stages
 ARG DCAP_VERSION=DCAP_1.20
@@ -21,6 +21,7 @@ RUN DEBIAN_FRONTEND=noninteractive \
     gnupg \
     git \
     zip \
+    python3-setuptools \
     && curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /usr/share/keyrings/nodesource.gpg \
     && echo "deb [signed-by=/usr/share/keyrings/nodesource.gpg] https://deb.nodesource.com/node_${NODE_MAJOR}.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list \
     && apt-get update -yq \
@@ -46,7 +47,7 @@ RUN npm config set proxy $http_proxy \
     && npm install
 
 # Start final image build
-FROM ubuntu:23.04
+FROM ubuntu:24.04
 
 # Create user and group before copying files
 ARG USER=pccs


### PR DESCRIPTION
Bump the base image from ubuntu23 to ubuntu24

- The Ubuntu 23.04 release ("Lunar") reached end of life (EOL) in January 2024

- See also https://stackoverflow.com/questions/69919970/no-module-named-distutils-util-but-distutils-is-installed/76691103#76691103