### PR TITLE
[Don't merge]feat(raiko): fast guest input generation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -472,10 +472,12 @@ dependencies = [
  "alloy-json-rpc 0.1.4",
  "alloy-network 0.1.4",
  "alloy-primitives 0.7.7",
+ "alloy-pubsub",
  "alloy-rpc-client",
  "alloy-rpc-types-eth 0.1.4",
  "alloy-transport",
  "alloy-transport-http",
+ "alloy-transport-ipc",
  "async-stream",
  "async-trait",
  "auto_impl",
@@ -490,6 +492,25 @@ dependencies = [
  "tokio",
  "tracing",
  "url",
+]
+
+[[package]]
+name = "alloy-pubsub"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a7341322d9bc0e49f6e9fd9f2eb8e30f73806f2dd12cbb3d6bab2694c921f87"
+dependencies = [
+ "alloy-json-rpc 0.1.4",
+ "alloy-primitives 0.7.7",
+ "alloy-transport",
+ "bimap",
+ "futures",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tokio-stream",
+ "tower 0.4.13",
+ "tracing",
 ]
 
 [[package]]
@@ -521,8 +542,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ba31bae67773fd5a60020bea900231f8396202b7feca4d0c70c6b59308ab4a8"
 dependencies = [
  "alloy-json-rpc 0.1.4",
+ "alloy-primitives 0.7.7",
+ "alloy-pubsub",
  "alloy-transport",
  "alloy-transport-http",
+ "alloy-transport-ipc",
  "futures",
  "pin-project",
  "reqwest 0.12.5",
@@ -930,6 +954,25 @@ dependencies = [
  "tower 0.4.13",
  "tracing",
  "url",
+]
+
+[[package]]
+name = "alloy-transport-ipc"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd7fbc8b6282ce41b01cbddef7bffb133fe6e1bf65dcd39770d45a905c051179"
+dependencies = [
+ "alloy-json-rpc 0.1.4",
+ "alloy-pubsub",
+ "alloy-transport",
+ "bytes",
+ "futures",
+ "interprocess",
+ "pin-project",
+ "serde_json",
+ "tokio",
+ "tokio-util",
+ "tracing",
 ]
 
 [[package]]
@@ -1587,6 +1630,12 @@ checksum = "3a8241f3ebb85c056b509d4327ad0358fbbba6ffb340bf388f26350aeda225b1"
 dependencies = [
  "serde",
 ]
+
+[[package]]
+name = "bimap"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "230c5f1ca6a325a32553f8640d31ac9b49f2411e901e427570154868b46da4f7"
 
 [[package]]
 name = "bincode"
@@ -2810,6 +2859,12 @@ name = "docker-generate"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf673e0848ef09fa4aeeba78e681cf651c0c7d35f76ee38cec8e55bc32fa111"
+
+[[package]]
+name = "doctest-file"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aac81fa3e28d21450aa4d2ac065992ba96a1d7303efbce51a95f4fd175b67562"
 
 [[package]]
 name = "dotenv"
@@ -4252,6 +4307,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "interprocess"
+version = "2.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "894148491d817cb36b6f778017b8ac46b17408d522dd90f539d677ea938362eb"
+dependencies = [
+ "doctest-file",
+ "futures-core",
+ "libc",
+ "recvmsg",
+ "tokio",
+ "widestring",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6071,6 +6141,7 @@ dependencies = [
  "alloy-network 0.1.4",
  "alloy-primitives 0.7.7",
  "alloy-provider",
+ "alloy-pubsub",
  "alloy-rlp",
  "alloy-rlp-derive",
  "alloy-rpc-client",
@@ -6460,6 +6531,12 @@ checksum = "3f87cc11a0140b4b0da0ffc889885760c61b13672d80a908920b2c0df078fa14"
 dependencies = [
  "rayon",
 ]
+
+[[package]]
+name = "recvmsg"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3edd4d5d42c92f0a659926464d4cce56b562761267ecf0f469d85b7de384175"
 
 [[package]]
 name = "redis"
@@ -10581,6 +10658,12 @@ dependencies = [
  "once_cell",
  "rustix",
 ]
+
+[[package]]
+name = "widestring"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7219d36b6eac893fa81e84ebe06485e7dcbb616177469b142df14f1f4deb1311"
 
 [[package]]
 name = "winapi"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3088,6 +3088,19 @@ dependencies = [
 
 [[package]]
 name = "env_logger"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a12e6657c4c97ebab115a42dcee77225f7f482cdd841cf7088c657a42e9e00e7"
+dependencies = [
+ "atty",
+ "humantime",
+ "log",
+ "regex",
+ "termcolor",
+]
+
+[[package]]
+name = "env_logger"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38b35839ba51819680ba087cd351788c9a3c476841207e0b8cee0b04722343b9"
@@ -6152,6 +6165,7 @@ dependencies = [
  "assert_cmd",
  "bincode",
  "clap 4.5.9",
+ "env_logger 0.9.3",
  "ethers-core",
  "kzg",
  "raiko-lib",
@@ -6199,7 +6213,7 @@ dependencies = [
  "cfg-if",
  "clap 4.5.9",
  "dotenv",
- "env_logger",
+ "env_logger 0.11.3",
  "ethers-core",
  "flate2",
  "kzg",
@@ -6377,7 +6391,7 @@ dependencies = [
  "cfg-if",
  "clap 4.5.9",
  "dirs",
- "env_logger",
+ "env_logger 0.11.3",
  "ethers-core",
  "file-lock",
  "flate2",
@@ -9565,6 +9579,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "termcolor"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "termtree"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9576,7 +9599,7 @@ version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3dffced63c2b5c7be278154d76b479f9f9920ed34e7574201407f0b14e2bbb93"
 dependencies = [
- "env_logger",
+ "env_logger 0.11.3",
  "test-log-macros",
  "tracing-subscriber 0.3.18",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -97,6 +97,7 @@ alloy-provider = { version = "0.1", default-features = false, features = [
 alloy-transport-http = { version = "0.1", default-features = false, features = [
     "reqwest",
 ] }
+alloy-pubsub = { version = "0.1", default-features = false}
 alloy-signer = { version = "0.1", default-features = false }
 alloy-signer-local = { version = "0.1", default-features = false }
 

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -26,11 +26,12 @@ alloy-rlp-derive = { workspace = true }
 alloy-sol-types = { workspace = true }
 alloy-primitives = { workspace = true }
 alloy-rpc-types = { workspace = true }
-alloy-provider = { workspace = true }
+alloy-provider = { workspace = true, features = ['ipc'] }
 alloy-transport-http = { workspace = true }
 alloy-consensus = { workspace = true }
 alloy-network = { workspace = true }
 alloy-rpc-client = { workspace = true }
+alloy-pubsub = {workspace = true}
 
 # tracing and logging
 tracing = { workspace = true }

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -65,6 +65,7 @@ clap = { workspace = true }
 assert_cmd = { workspace = true }
 rstest = { workspace = true }
 ethers-core = { workspace = true }
+env_logger = "0.9.0"
 
 [features]
 # powdr = ["dep:powdr"]

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -505,7 +505,10 @@ mod tests {
         let proof_type = get_proof_type_from_env();
         let l1_network = "ethereum".to_owned();
         let network = "taiko_mainnet".to_owned();
-        let block_number = 600001;
+        let block_number = std::env::var("BLOCK_NUMBER")
+            .unwrap_or_else(|_| "1".to_string())
+            .parse::<u64>()
+            .unwrap();
         let chain_specs = SupportedChainSpecs::merge_from_file(
             "../host/config/chain_spec_list_default.json".into(),
         )

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -3,7 +3,7 @@ use std::{collections::HashMap, hint::black_box};
 use alloy_primitives::Address;
 use alloy_rpc_types::EIP1186AccountProofResponse;
 use interfaces::{cancel_proof, run_prover};
-use provider::GuestInputProvider;
+use preflight::sidecar::GuestInputProvider;
 use raiko_lib::{
     builder::{create_mem_db, RethBlockBuilder},
     consts::ChainSpec,
@@ -88,6 +88,10 @@ impl Raiko {
     }
 
     pub fn get_output(&self, input: &GuestInput) -> RaikoResult<GuestOutput> {
+        info!(
+            "Building block output for block {}",
+            self.request.block_number
+        );
         let db = create_mem_db(&mut input.clone()).unwrap();
         let mut builder = RethBlockBuilder::new(input, db);
         builder.execute_transactions(false).expect("execute");
@@ -230,7 +234,7 @@ pub fn merge(a: &mut Value, b: &Value) {
 #[cfg(test)]
 mod tests {
     use crate::interfaces::aggregate_proofs;
-    use crate::provider::GuestInputProviderImpl;
+    use crate::preflight::sidecar::GuestInputProviderImpl;
     use crate::{interfaces::ProofRequest, provider::rpc::RpcBlockDataProvider, ChainSpec, Raiko};
     use alloy_primitives::Address;
     use alloy_provider::Provider;

--- a/core/src/preflight/mod.rs
+++ b/core/src/preflight/mod.rs
@@ -95,6 +95,7 @@ pub async fn preflight<BDP: BlockDataProvider>(
         ..Default::default()
     };
 
+    let measurement = Measurement::start("Fetching and execution...", true);
     // Create the block builder, run the transactions and extract the DB
     let provider_db = ProviderDb::new(provider, taiko_chain_spec, parent_block_number).await?;
 
@@ -103,7 +104,7 @@ pub async fn preflight<BDP: BlockDataProvider>(
 
     // Optimize data gathering by executing the transactions multiple times so data can be requested in batches
     execute_txs(&mut builder).await?;
-
+    measurement.stop();
     let Some(db) = builder.db.as_mut() else {
         return Err(RaikoError::Preflight("No db in builder".to_owned()));
     };

--- a/core/src/preflight/mod.rs
+++ b/core/src/preflight/mod.rs
@@ -17,6 +17,7 @@ use crate::{
 use util::{execute_txs, get_block_and_parent_data, prepare_taiko_chain_input};
 
 mod util;
+pub mod sidecar;
 
 pub struct PreflightData {
     pub block_number: u64,

--- a/core/src/preflight/sidecar.rs
+++ b/core/src/preflight/sidecar.rs
@@ -1,0 +1,26 @@
+use raiko_lib::input::{GuestInput, GuestOutput};
+use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
+
+/// for raiko use
+/// to support use case like raiko reads guest input from remote raiko
+/// 
+
+
+#[derive(Debug, Serialize, ToSchema, Deserialize)]
+/// The response body of a proof request.
+pub struct ProofResponse {
+    #[schema(value_type = Option<GuestInput>)]
+    /// The input of the prover.
+    pub input: Option<GuestInput>,
+    #[schema(value_type = Option<GuestOutputDoc>)]
+    /// The output of the prover.
+    pub output: Option<GuestOutput>,
+}
+
+#[derive(Debug, Deserialize, Serialize, ToSchema)]
+#[serde(tag = "status", rename_all = "lowercase")]
+pub enum Status {
+    Ok { data: ProofResponse },
+    Error { error: String, message: String },
+}

--- a/core/src/preflight/sidecar.rs
+++ b/core/src/preflight/sidecar.rs
@@ -4,8 +4,7 @@ use utoipa::ToSchema;
 
 /// for raiko use
 /// to support use case like raiko reads guest input from remote raiko
-/// 
-
+///
 
 #[derive(Debug, Serialize, ToSchema, Deserialize)]
 /// The response body of a proof request.
@@ -19,8 +18,233 @@ pub struct ProofResponse {
 }
 
 #[derive(Debug, Deserialize, Serialize, ToSchema)]
-#[serde(tag = "status", rename_all = "lowercase")]
+#[serde(rename_all = "lowercase")]
 pub enum Status {
     Ok { data: ProofResponse },
     Error { error: String, message: String },
+}
+
+#[cfg(test)]
+mod test {
+    use core::{fmt::Debug, str::FromStr};
+    use std::u128;
+
+    use anyhow::{anyhow, Error, Result};
+    use raiko_lib::input::{
+        ontake::BlockProposedV2, BlobProofType, BlockProposed, BlockProposedFork, GuestOutput,
+        TaikoProverData,
+    };
+    use reth_primitives::{
+        revm_primitives::{Address, Bytes, HashMap, B256, U256},
+        Header, TransactionSigned, TxEip1559,
+    };
+    use serde::{Deserialize, Serialize};
+    use serde_with::serde_as;
+
+    pub type StorageEntry = (MptNode, Vec<U256>);
+
+    use raiko_lib::{consts::ChainSpec, input::TaikoGuestInput, primitives::mpt::MptNode};
+    use utoipa::ToSchema;
+
+    #[derive(Clone, Debug, Default, Serialize, Deserialize)]
+
+    pub enum BlockProposedForkRef {
+        #[default]
+        Nothing,
+        Hekla(BlockProposed),
+        Ontake(BlockProposedV2Ref),
+    }
+
+    #[serde_as]
+    #[derive(Clone, Debug, Default, Serialize, Deserialize)]
+    pub struct TaikoGuestInputRef {
+        /// header
+        // pub l1_header: Header,
+        // pub tx_data: Vec<u8>,
+        pub anchor_tx: Option<TransactionSigned>,
+        pub block_proposed: BlockProposedForkRef,
+        // pub prover_data: TaikoProverData,
+        // pub blob_commitment: Option<Vec<u8>>,
+        // pub blob_proof: Option<Vec<u8>>,
+        // pub blob_proof_type: BlobProofType,
+    }
+
+    #[serde_as]
+    #[derive(Debug, Clone, Default, Deserialize, Serialize)]
+    pub struct GuestInputRef {
+        // /// Reth block
+        // pub block: BlockV2,
+        // /// The network to generate the proof for
+        // pub chain_spec: ChainSpec,
+        // /// Previous block header
+        // pub parent_header: Header,
+        // /// State trie of the parent block.
+        // pub parent_state_trie: MptNode,
+        // /// Maps each address with its storage trie and the used storage slots.
+        // pub parent_storage: HashMap<Address, StorageEntry>,
+        // /// The code of all unique contracts.
+        // pub contracts: Vec<Bytes>,
+        // /// List of at most 256 previous block headers
+        // pub ancestor_headers: Vec<Header>,
+        // // /// Taiko specific data
+        pub taiko: TaikoGuestInputRef,
+    }
+
+    #[derive(Debug, Serialize, ToSchema, Deserialize)]
+    /// The response body of a proof request.
+    pub struct ProofResponse {
+        #[schema(value_type = Option<GuestInput>)]
+        /// The input of the prover.
+        pub input: Option<GuestInputRef>,
+        // #[schema(value_type = Option<GuestOutputDoc>)]
+        // /// The output of the prover.
+        // pub output: Option<GuestOutput>,
+    }
+
+    #[derive(Debug, Deserialize, Serialize, ToSchema)]
+    // #[serde(tag = "status", rename_all = "lowercase")]
+    #[serde(rename_all = "lowercase")]
+    pub enum Status {
+        Ok { data: ProofResponse },
+        Error { error: String, message: String },
+    }
+
+    #[test]
+    fn test_ser_der_status() {
+        let mut tx = TxEip1559::default();
+        tx.max_fee_per_gas = u128::MAX - 5;
+        let anchor_tx = TransactionSigned {
+            hash: Default::default(),
+            signature: Default::default(),
+            transaction: reth_primitives::Transaction::Eip1559(tx)
+        };
+        let input = GuestInputRef {
+            // block: BlockV2::default(), 
+            // chain_spec: ChainSpec::default(),
+            // parent_header: Header::default(),
+            // parent_state_trie: MptNode::default(),
+            // parent_storage: HashMap::default(),
+            // contracts: vec![Bytes::default()],
+            // ancestor_headers: vec![Header::default()],
+            taiko: TaikoGuestInputRef {
+                block_proposed: BlockProposedForkRef::Ontake(BlockProposedV2Ref {
+                    blockId: Default::default(),
+                    meta: BlockMetadataV2Ref {
+                        livenessBond: u128::MAX >> 33,
+                    },
+                }),
+                anchor_tx: Some(anchor_tx),
+            },
+        };
+
+        let status = Status::Ok {
+            data: ProofResponse { input: Some(input) },
+        };
+
+        let serialized = serde_json::to_string(&status).unwrap();
+        let deserialized: Status = serde_json::from_str(&serialized).unwrap();
+
+        // assert_eq!(input, deserialized);
+        print!("{:?}", deserialized);
+    }
+
+    #[test]
+    fn test_ser_der() {
+        let input = GuestInputRef {
+            // block: BlockV2::default(),
+            // chain_spec: ChainSpec::default(),
+            // parent_header: Header::default(),
+            // parent_state_trie: MptNode::default(),
+            // parent_storage: HashMap::default(),
+            // contracts: vec![Bytes::default()],
+            // ancestor_headers: vec![Header::default()],
+            taiko: TaikoGuestInputRef {
+                block_proposed: BlockProposedForkRef::Ontake(BlockProposedV2Ref {
+                    blockId: Default::default(),
+                    meta: BlockMetadataV2Ref {
+                        livenessBond: u128::MAX >> 33,
+                    },
+                }),
+                ..Default::default()
+            },
+        };
+
+        let serialized = serde_json::to_string(&input).unwrap();
+        let deserialized: GuestInputRef = serde_json::from_str(&serialized).unwrap();
+
+        // assert_eq!(input, deserialized);
+        print!("{:?}", deserialized);
+    }
+
+    #[test]
+    fn test_deser_files() {
+        let json_str = include_str!("../../../response.log");
+        let deserialized = serde_json::from_str::<Status>(json_str);
+        println!("{:?}", deserialized);
+    }
+
+    use alloy_sol_types::sol;
+    sol! {
+        #[derive(Serialize, Deserialize, Debug)]
+        struct SolRef {
+            uint96 data;
+        }
+
+        #[derive(Debug, Default, Deserialize, Serialize)]
+        struct BlockMetadataV2Ref {
+            // bytes32 anchorBlockHash; // `_l1BlockHash` in TaikoL2's anchor tx.
+            // bytes32 difficulty;
+            // bytes32 blobHash;
+            // bytes32 extraData;
+            // address coinbase;
+            // uint64 id;
+            // uint32 gasLimit;
+            // uint64 timestamp;
+            // uint64 anchorBlockId; // `_l1BlockId` in TaikoL2's anchor tx.
+            // uint16 minTier;
+            // bool blobUsed;
+            // bytes32 parentMetaHash;
+            // address proposer;
+            uint96 livenessBond;
+            // // Time this block is proposed at, used to check proving window and cooldown window.
+            // uint64 proposedAt;
+            // // L1 block number, required/used by node/client.
+            // uint64 proposedIn;
+            // uint32 blobTxListOffset;
+            // uint32 blobTxListLength;
+            // uint8 blobIndex;
+            // BaseFeeConfig baseFeeConfig;
+        }
+
+        #[derive(Debug, Default, Deserialize, Serialize)]
+        event BlockProposedV2Ref(uint256 indexed blockId, BlockMetadataV2Ref meta);
+
+    }
+
+    #[derive(Serialize, Deserialize, Debug)]
+    struct JsonRef {
+        data: u128,
+    }
+
+    #[test]
+    fn test_simple_u128_json() {
+        let json_str = serde_json::to_string(&JsonRef {
+            data: u128::MAX - 1,
+        });
+        println!("json_str = {:?}.", json_str);
+
+        let json_obj = serde_json::from_str::<JsonRef>(&json_str.unwrap());
+        println!("json_obj = {:?}.", json_obj);
+
+        let test_json_str = "{\"data\": 125000000000000000000}";
+        let json_obj = serde_json::from_str::<JsonRef>(test_json_str);
+        println!("json_obj from str= {:?}.", json_obj);
+    }
+
+    #[test]
+    fn test_simple_sol_u96_json() {
+        let test_json_str = "{\"data\": 125000000000000000000}";
+        let json_obj = serde_json::from_str::<SolRef>(test_json_str);
+        println!("json_obj from str= {:?}.", json_obj);
+    }
 }

--- a/core/src/provider/ipc.rs
+++ b/core/src/provider/ipc.rs
@@ -329,6 +329,7 @@ impl BlockDataProvider for IpcBlockDataProvider {
 #[cfg(test)]
 mod tests {
     use alloy_primitives::{Address, U256};
+    use alloy_rpc_types::BlockTransactionsKind;
 
     use super::*;
     use std::collections::HashMap;
@@ -339,6 +340,22 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(provider.block_number, 1);
+    }
+
+    #[tokio::test]
+    async fn test_ipc_block_data_provider_get_block() {
+        let provider = IpcBlockDataProvider::new("ipc:/tmp/geth.ipc", 1)
+            .await
+            .unwrap();
+        let latest_block = provider.provider.get_block_number().await;
+        println!("Latest block: {latest_block:?}");
+
+        let block = provider
+            .provider
+            .get_block(1.into(), BlockTransactionsKind::Full)
+            .await
+            .unwrap();
+        print!("block info: {:?}", block);
     }
 
     #[tokio::test]

--- a/core/src/provider/ipc.rs
+++ b/core/src/provider/ipc.rs
@@ -1,0 +1,384 @@
+use alloy_primitives::{Address, Bytes, StorageKey, Uint, U256};
+use alloy_provider::{IpcConnect, Provider, ProviderBuilder, RootProvider};
+use alloy_pubsub::PubSubFrontend;
+use alloy_rpc_client::BatchRequest;
+use alloy_rpc_types::{Block, BlockId, BlockNumberOrTag, EIP1186AccountProofResponse};
+use raiko_lib::clear_line;
+use reth_primitives::revm_primitives::{AccountInfo, Bytecode};
+use std::collections::HashMap;
+
+use crate::{
+    interfaces::{RaikoError, RaikoResult},
+    provider::BlockDataProvider,
+    MerkleProof,
+};
+
+pub type IpcProvider<N = alloy_network::Ethereum> = RootProvider<PubSubFrontend, N>;
+
+#[derive(Clone)]
+pub struct IpcBlockDataProvider {
+    pub provider: IpcProvider,
+    block_number: u64,
+}
+
+impl IpcBlockDataProvider {
+    pub async fn new(url: &str, block_number: u64) -> RaikoResult<Self> {
+        assert!(url.contains("ipc:"), "Invalid IPC URL");
+        // get ipc:(*) from url as ipc path
+        let ipc_path = url.split(':').collect::<Vec<&str>>()[1].to_string();
+
+        let ipc = IpcConnect::new(ipc_path);
+        Ok(Self {
+            provider: {
+                ProviderBuilder::new()
+                    .on_ipc(ipc)
+                    .await
+                    .map_err(|e| RaikoError::RPC(format!("Failed to create IPC provider: {e}")))?
+            },
+            block_number,
+        })
+    }
+
+    pub fn provider(&self) -> &IpcProvider {
+        &self.provider
+    }
+}
+
+impl BlockDataProvider for IpcBlockDataProvider {
+    async fn get_blocks(&self, blocks_to_fetch: &[(u64, bool)]) -> RaikoResult<Vec<Block>> {
+        let mut all_blocks = Vec::with_capacity(blocks_to_fetch.len());
+
+        let max_batch_size = 32;
+        for blocks_to_fetch in blocks_to_fetch.chunks(max_batch_size) {
+            let mut batch = BatchRequest::new(self.provider.client());
+            let mut requests = Vec::with_capacity(max_batch_size);
+
+            for (block_number, full) in blocks_to_fetch {
+                requests.push(Box::pin(
+                    batch
+                        .add_call(
+                            "eth_getBlockByNumber",
+                            &(BlockNumberOrTag::from(*block_number), full),
+                        )
+                        .map_err(|_| {
+                            RaikoError::RPC(
+                                "Failed adding eth_getBlockByNumber call to batch".to_owned(),
+                            )
+                        })?,
+                ));
+            }
+
+            batch.send().await.map_err(|e| {
+                RaikoError::RPC(format!(
+                    "Error sending batch request for block {blocks_to_fetch:?}: {e}"
+                ))
+            })?;
+
+            let mut blocks = Vec::with_capacity(max_batch_size);
+            // Collect the data from the batch
+            for request in requests {
+                blocks.push(
+                    request.await.map_err(|e| {
+                        RaikoError::RPC(format!("Error collecting request data: {e}"))
+                    })?,
+                );
+            }
+
+            all_blocks.append(&mut blocks);
+        }
+
+        Ok(all_blocks)
+    }
+
+    async fn get_accounts(&self, accounts: &[Address]) -> RaikoResult<Vec<AccountInfo>> {
+        let mut all_accounts = Vec::with_capacity(accounts.len());
+
+        let max_batch_size = 250;
+        for accounts in accounts.chunks(max_batch_size) {
+            let mut batch = BatchRequest::new(self.provider.client());
+
+            let mut nonce_requests = Vec::with_capacity(max_batch_size);
+            let mut balance_requests = Vec::with_capacity(max_batch_size);
+            let mut code_requests = Vec::with_capacity(max_batch_size);
+
+            for address in accounts {
+                nonce_requests.push(Box::pin(
+                    batch
+                        .add_call::<_, Uint<64, 1>>(
+                            "eth_getTransactionCount",
+                            &(address, Some(BlockId::from(self.block_number))),
+                        )
+                        .map_err(|_| {
+                            RaikoError::RPC(
+                                "Failed adding eth_getTransactionCount call to batch".to_owned(),
+                            )
+                        })?,
+                ));
+                balance_requests.push(Box::pin(
+                    batch
+                        .add_call::<_, Uint<256, 4>>(
+                            "eth_getBalance",
+                            &(address, Some(BlockId::from(self.block_number))),
+                        )
+                        .map_err(|_| {
+                            RaikoError::RPC("Failed adding eth_getBalance call to batch".to_owned())
+                        })?,
+                ));
+                code_requests.push(Box::pin(
+                    batch
+                        .add_call::<_, Bytes>(
+                            "eth_getCode",
+                            &(address, Some(BlockId::from(self.block_number))),
+                        )
+                        .map_err(|_| {
+                            RaikoError::RPC("Failed adding eth_getCode call to batch".to_owned())
+                        })?,
+                ));
+            }
+
+            batch
+                .send()
+                .await
+                .map_err(|e| RaikoError::RPC(format!("Error sending batch request {e}")))?;
+
+            let mut accounts = vec![];
+            // Collect the data from the batch
+            for ((nonce_request, balance_request), code_request) in nonce_requests
+                .into_iter()
+                .zip(balance_requests.into_iter())
+                .zip(code_requests.into_iter())
+            {
+                let (nonce, balance, code) = (
+                    nonce_request.await.map_err(|e| {
+                        RaikoError::RPC(format!("Failed to collect nonce request: {e}"))
+                    })?,
+                    balance_request.await.map_err(|e| {
+                        RaikoError::RPC(format!("Failed to collect balance request: {e}"))
+                    })?,
+                    code_request.await.map_err(|e| {
+                        RaikoError::RPC(format!("Failed to collect code request: {e}"))
+                    })?,
+                );
+
+                let nonce = nonce.try_into().map_err(|_| {
+                    RaikoError::Conversion("Failed to convert nonce to u64".to_owned())
+                })?;
+
+                let bytecode = Bytecode::new_raw(code);
+
+                let account_info = AccountInfo::new(balance, nonce, bytecode.hash_slow(), bytecode);
+
+                accounts.push(account_info);
+            }
+
+            all_accounts.append(&mut accounts);
+        }
+
+        Ok(all_accounts)
+    }
+
+    async fn get_storage_values(&self, accounts: &[(Address, U256)]) -> RaikoResult<Vec<U256>> {
+        let mut all_values = Vec::with_capacity(accounts.len());
+
+        let max_batch_size = 1000;
+        for accounts in accounts.chunks(max_batch_size) {
+            let mut batch = BatchRequest::new(self.provider.client());
+
+            let mut requests = Vec::with_capacity(max_batch_size);
+
+            for (address, key) in accounts {
+                requests.push(Box::pin(
+                    batch
+                        .add_call::<_, U256>(
+                            "eth_getStorageAt",
+                            &(address, key, Some(BlockId::from(self.block_number))),
+                        )
+                        .map_err(|_| {
+                            RaikoError::RPC(
+                                "Failed adding eth_getStorageAt call to batch".to_owned(),
+                            )
+                        })?,
+                ));
+            }
+
+            batch
+                .send()
+                .await
+                .map_err(|e| RaikoError::RPC(format!("Error sending batch request {e}")))?;
+
+            let mut values = Vec::with_capacity(max_batch_size);
+            // Collect the data from the batch
+            for request in requests {
+                values.push(
+                    request.await.map_err(|e| {
+                        RaikoError::RPC(format!("Error collecting request data: {e}"))
+                    })?,
+                );
+            }
+
+            all_values.append(&mut values);
+        }
+
+        Ok(all_values)
+    }
+
+    async fn get_merkle_proofs(
+        &self,
+        block_number: u64,
+        accounts: HashMap<Address, Vec<U256>>,
+        offset: usize,
+        num_storage_proofs: usize,
+    ) -> RaikoResult<MerkleProof> {
+        let mut storage_proofs: MerkleProof = HashMap::new();
+        let mut idx = offset;
+
+        let mut accounts = accounts.clone();
+
+        let batch_limit = 1000;
+        while !accounts.is_empty() {
+            #[cfg(debug_assertions)]
+            raiko_lib::inplace_print(&format!(
+                "fetching storage proof {idx}/{num_storage_proofs}..."
+            ));
+            #[cfg(not(debug_assertions))]
+            tracing::trace!("Fetching storage proof {idx}/{num_storage_proofs}...");
+
+            // Create a batch for all storage proofs
+            let mut batch = BatchRequest::new(self.provider.client());
+
+            // Collect all requests
+            let mut requests = Vec::new();
+
+            let mut batch_size = 0;
+            while !accounts.is_empty() && batch_size < batch_limit {
+                let mut address_to_remove = None;
+
+                if let Some((address, keys)) = accounts.iter_mut().next() {
+                    // Calculate how many keys we can still process
+                    let num_keys_to_process = if batch_size + keys.len() < batch_limit {
+                        keys.len()
+                    } else {
+                        batch_limit - batch_size
+                    };
+
+                    // If we can process all keys, remove the address from the map after the loop
+                    if num_keys_to_process == keys.len() {
+                        address_to_remove = Some(*address);
+                    }
+
+                    // Extract the keys to process
+                    let keys_to_process = keys
+                        .drain(0..num_keys_to_process)
+                        .map(StorageKey::from)
+                        .collect::<Vec<_>>();
+
+                    // Add the request
+                    requests.push(Box::pin(
+                        batch
+                            .add_call::<_, EIP1186AccountProofResponse>(
+                                "eth_getProof",
+                                &(
+                                    *address,
+                                    keys_to_process.clone(),
+                                    BlockId::from(block_number),
+                                ),
+                            )
+                            .map_err(|_| {
+                                RaikoError::RPC(
+                                    "Failed adding eth_getProof call to batch".to_owned(),
+                                )
+                            })?,
+                    ));
+
+                    // Keep track of how many keys were processed
+                    // Add an additional 1 for the account proof itself
+                    batch_size += 1 + keys_to_process.len();
+                }
+
+                // Remove the address if all keys were processed for this account
+                if let Some(address) = address_to_remove {
+                    accounts.remove(&address);
+                }
+            }
+
+            // Send the batch
+            batch
+                .send()
+                .await
+                .map_err(|e| RaikoError::RPC(format!("Error sending batch request {e}")))?;
+
+            // Collect the data from the batch
+            for request in requests {
+                let mut proof = request
+                    .await
+                    .map_err(|e| RaikoError::RPC(format!("Error collecting request data: {e}")))?;
+                idx += proof.storage_proof.len();
+                if let Some(map_proof) = storage_proofs.get_mut(&proof.address) {
+                    map_proof.storage_proof.append(&mut proof.storage_proof);
+                } else {
+                    storage_proofs.insert(proof.address, proof);
+                }
+            }
+        }
+        clear_line();
+
+        Ok(storage_proofs)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloy_primitives::{Address, U256};
+
+    use super::*;
+    use std::collections::HashMap;
+
+    #[tokio::test]
+    async fn test_ipc_block_data_provider() {
+        let provider = IpcBlockDataProvider::new("ipc:/tmp/geth.ipc", 1)
+            .await
+            .unwrap();
+        assert_eq!(provider.block_number, 1);
+    }
+
+    #[tokio::test]
+    async fn test_ipc_block_data_provider_get_blocks() {
+        let provider = IpcBlockDataProvider::new("ipc:/tmp/geth.ipc", 1)
+            .await
+            .unwrap();
+        let blocks = provider.get_blocks(&[(1, true)]).await.unwrap();
+        assert_eq!(blocks.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn test_ipc_block_data_provider_get_accounts() {
+        let provider = IpcBlockDataProvider::new("ipc:/tmp/geth.ipc", 1)
+            .await
+            .unwrap();
+        let accounts = provider.get_accounts(&[Address::default()]).await.unwrap();
+        assert_eq!(accounts.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn test_ipc_block_data_provider_get_storage_values() {
+        let provider = IpcBlockDataProvider::new("ipc:/tmp/geth.ipc", 1)
+            .await
+            .unwrap();
+        let values = provider
+            .get_storage_values(&[(Address::default(), U256::default())])
+            .await
+            .unwrap();
+        assert_eq!(values.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn test_ipc_block_data_provider_get_merkle_proofs() {
+        let provider = IpcBlockDataProvider::new("ipc:/tmp/geth.ipc", 1)
+            .await
+            .unwrap();
+        let mut accounts = HashMap::new();
+        accounts.insert(Address::default().into(), vec![U256::default()]);
+        let proof = provider.get_merkle_proofs(1, accounts, 0, 1).await.unwrap();
+        assert_eq!(proof.len(), 1);
+    }
+}

--- a/core/src/provider/ipc.rs
+++ b/core/src/provider/ipc.rs
@@ -363,7 +363,10 @@ mod tests {
         let provider = IpcBlockDataProvider::new("ipc:/tmp/geth.ipc", 1)
             .await
             .unwrap();
-        let blocks = provider.get_blocks(&[(1, true)]).await.unwrap();
+        let blocks = provider
+            .get_blocks((1..=1).map(|i| (i, true)).collect::<Vec<_>>().as_slice())
+            .await
+            .unwrap();
         assert_eq!(blocks.len(), 1);
     }
 

--- a/core/src/provider/ipc.rs
+++ b/core/src/provider/ipc.rs
@@ -364,10 +364,14 @@ mod tests {
             .await
             .unwrap();
         let blocks = provider
-            .get_blocks((1..=1).map(|i| (i, true)).collect::<Vec<_>>().as_slice())
+            .get_blocks((1..=5).map(|i| (i, true)).collect::<Vec<_>>().as_slice())
             .await
             .unwrap();
-        assert_eq!(blocks.len(), 1);
+        assert_eq!(blocks.len(), 5);
+        assert!(blocks
+            .iter()
+            .enumerate()
+            .all(|(i, b)| b.header.number == Some(i as u64)));
     }
 
     #[tokio::test]

--- a/core/src/provider/mod.rs
+++ b/core/src/provider/mod.rs
@@ -12,6 +12,7 @@ use crate::{
 
 pub mod db;
 pub mod rpc;
+pub mod ipc;
 
 #[allow(async_fn_in_trait)]
 pub trait BlockDataProvider {

--- a/core/src/provider/mod.rs
+++ b/core/src/provider/mod.rs
@@ -1,18 +1,76 @@
 use alloy_primitives::{Address, B256, U256};
 use alloy_rpc_types::Block;
-use raiko_lib::consts::SupportedChainSpecs;
+use raiko_lib::{consts::SupportedChainSpecs, input::GuestInput};
 use reth_primitives::revm_primitives::AccountInfo;
 use std::collections::HashMap;
+use tracing::{info, warn};
 
 use crate::{
-    interfaces::{RaikoError, RaikoResult},
-    provider::rpc::RpcBlockDataProvider,
+    interfaces::{ProofRequest, RaikoError, RaikoResult},
+    preflight::sidecar::Status,
+    provider::{ipc::IpcBlockDataProvider, rpc::RpcBlockDataProvider},
     MerkleProof,
 };
 
 pub mod db;
-pub mod rpc;
 pub mod ipc;
+pub mod rpc;
+
+#[allow(async_fn_in_trait)]
+pub trait GuestInputProvider {
+    async fn get_guest_input(&self, url: &str, request: &ProofRequest) -> RaikoResult<GuestInput>;
+}
+
+pub struct GuestInputProviderImpl;
+
+impl GuestInputProvider for GuestInputProviderImpl {
+    async fn get_guest_input(
+        &self,
+        input_provider_url: &str,
+        request: &ProofRequest,
+    ) -> RaikoResult<GuestInput> {
+        // use request client to post request
+        let url = format!("{}/v1/input", input_provider_url.trim_end_matches('/'),);
+        info!("Retrieve side car guest input from {url}.");
+
+        let response = reqwest::Client::new()
+            .post(url.clone())
+            .json(request)
+            .send()
+            .await
+            .map_err(|e| {
+                RaikoError::RPC(
+                    format!("Failed to send POST request: {}", e.to_string()).to_owned(),
+                )
+            })?;
+
+        if !response.status().is_success() {
+            warn!(
+                "Request {url} failed with status code: {}",
+                response.status()
+            );
+            return Err(RaikoError::RPC(
+                format!("Request failed with status code: {}", response.status()).to_owned(),
+            ));
+        }
+        let response_text = response.text().await.map_err(|e| {
+            RaikoError::RPC(format!("Failed to get response text: {}", e.to_string()).to_owned())
+        })?;
+        info!("Received response: {}", &response_text[..100]);
+        let response_json: Status = serde_json::from_str(&response_text).map_err(|e| {
+            RaikoError::RPC(format!("Failed to parse JSON: {}", e.to_string()).to_owned())
+        })?;
+
+        match response_json {
+            Status::Ok { data } => data
+                .input
+                .ok_or_else(|| RaikoError::RPC("No guest input in response".to_string())),
+            Status::Error { error, message } => {
+                Err(RaikoError::RPC(format!("Error: {} - {}", error, message)))
+            }
+        }
+    }
+}
 
 #[allow(async_fn_in_trait)]
 pub trait BlockDataProvider {
@@ -49,4 +107,65 @@ pub async fn get_task_data(
         .hash
         .ok_or_else(|| RaikoError::RPC("No block hash for requested block".to_string()))?;
     Ok((taiko_chain_spec.chain_id, blockhash))
+}
+
+pub enum BlockDataProviderType {
+    Rpc(RpcBlockDataProvider),
+    Ipc(IpcBlockDataProvider),
+}
+
+impl BlockDataProviderType {
+    pub async fn new(url: &str, block_number: u64, use_ipc: bool) -> RaikoResult<Self> {
+        if use_ipc {
+            Ok(Self::Ipc(
+                IpcBlockDataProvider::new(url, block_number - 1).await?,
+            ))
+        } else {
+            Ok(Self::Rpc(RpcBlockDataProvider::new(url, block_number - 1)?))
+        }
+    }
+}
+
+impl BlockDataProvider for BlockDataProviderType {
+    async fn get_blocks(&self, blocks_to_fetch: &[(u64, bool)]) -> RaikoResult<Vec<Block>> {
+        match self {
+            Self::Rpc(provider) => provider.get_blocks(blocks_to_fetch).await,
+            Self::Ipc(provider) => provider.get_blocks(blocks_to_fetch).await,
+        }
+    }
+
+    async fn get_accounts(&self, accounts: &[Address]) -> RaikoResult<Vec<AccountInfo>> {
+        match self {
+            Self::Rpc(provider) => provider.get_accounts(accounts).await,
+            Self::Ipc(provider) => provider.get_accounts(accounts).await,
+        }
+    }
+
+    async fn get_storage_values(&self, accounts: &[(Address, U256)]) -> RaikoResult<Vec<U256>> {
+        match self {
+            Self::Rpc(provider) => provider.get_storage_values(accounts).await,
+            Self::Ipc(provider) => provider.get_storage_values(accounts).await,
+        }
+    }
+
+    async fn get_merkle_proofs(
+        &self,
+        block_number: u64,
+        accounts: HashMap<Address, Vec<U256>>,
+        offset: usize,
+        num_storage_proofs: usize,
+    ) -> RaikoResult<MerkleProof> {
+        match self {
+            Self::Rpc(provider) => {
+                provider
+                    .get_merkle_proofs(block_number, accounts, offset, num_storage_proofs)
+                    .await
+            }
+            Self::Ipc(provider) => {
+                provider
+                    .get_merkle_proofs(block_number, accounts, offset, num_storage_proofs)
+                    .await
+            }
+        }
+    }
 }

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -88,6 +88,14 @@ function update_docker_chain_specs() {
     if [ -n "${TAIKO_MAINNET_RPC}" ]; then
         update_chain_spec_json $CONFIG_FILE "taiko_mainnet" "rpc" $TAIKO_MAINNET_RPC
     fi
+
+    if [ -n "${TAIKO_DEV_L1_RPC}" ]; then
+        update_chain_spec_json $CONFIG_FILE "taiko_dev_l1" "rpc" $TAIKO_DEV_L1_RPC
+    fi
+
+    if [ -n "${TAIKO_DEV_RPC}" ]; then
+        update_chain_spec_json $CONFIG_FILE "taiko_dev" "rpc" $TAIKO_DEV_RPC
+    fi
 }
 
 function update_config_json() {

--- a/host/src/server/api/v1/input.rs
+++ b/host/src/server/api/v1/input.rs
@@ -61,7 +61,20 @@ async fn input_handler(
         .expect("input generation failed");
     let elapsed = start_time.elapsed();
     observe_prepare_input_time(block_number, elapsed, true);
+    info!(
+        "generate guest input for block_number: {}, done",
+        block_number
+    );
+
+    let start_time = Instant::now();
     raiko.get_output(&input).expect("output generation failed");
+    let elapsed = start_time.elapsed();
+    observe_prepare_input_time(block_number, elapsed, true);
+    info!(
+        "generate guest output for block_number: {}, done",
+        block_number
+    );
+
     Ok(axum::Json(Status::Ok {
         data: ProofResponse {
             input: Some(input),

--- a/host/src/server/api/v1/input.rs
+++ b/host/src/server/api/v1/input.rs
@@ -1,0 +1,83 @@
+use axum::{extract::State, routing::post, Json, Router};
+use raiko_core::{interfaces::ProofRequest, provider::rpc::RpcBlockDataProvider, Raiko};
+use raiko_lib::consts::SupportedChainSpecs;
+use serde_json::Value;
+use tokio::time::Instant;
+use tracing::info;
+use utoipa::OpenApi;
+
+use crate::{
+    interfaces::HostResult,
+    metrics::observe_prepare_input_time,
+    server::api::v1::{ProofResponse, Status},
+};
+use raiko_reqactor::Actor;
+
+#[utoipa::path(post, path = "/input",
+    tag = "Proving",
+    request_body = ProofRequestOpt,
+    responses (
+        (status = 200, description = "Successfully created proof for request", body = Status)
+    )
+)]
+/// Generate a proof for requested config.
+///
+/// Accepts a proof request and generates a proof with the specified guest prover.
+/// The guest provers currently available are:
+/// - native - constructs a block and checks for equality
+/// - sgx - uses the sgx environment to construct a block and produce proof of execution
+/// - sp1 - uses the sp1 prover
+/// - risc0 - uses the risc0 prover
+async fn input_handler(
+    State(actor): State<Actor>,
+    Json(req): Json<Value>,
+) -> HostResult<Json<Status>> {
+    // Override the existing proof request config from the config file and command line
+    // options with the request from the client.
+    let mut config = actor.default_request_config().clone();
+    config.merge(&req)?;
+
+    let proof_request = ProofRequest::try_from(config)?;
+
+    let network = proof_request.network.clone();
+    // Skip test on SP1 for now because it's too slow on CI
+    let l1_network = proof_request.l1_network.clone();
+    let taiko_chain_spec = SupportedChainSpecs::default()
+        .get_chain_spec(&network)
+        .unwrap();
+    let l1_chain_spec = SupportedChainSpecs::default()
+        .get_chain_spec(&l1_network)
+        .unwrap();
+    let block_number = proof_request.block_number;
+    info!("generate guest input for block_number: {}", block_number);
+
+    let start_time = Instant::now();
+    let provider = RpcBlockDataProvider::new(&taiko_chain_spec.rpc, proof_request.block_number - 1)
+        .expect("Could not create RpcBlockDataProvider");
+    let raiko = Raiko::new(l1_chain_spec, taiko_chain_spec, proof_request.clone());
+    let input = raiko
+        .generate_input(provider)
+        .await
+        .expect("input generation failed");
+    let elapsed = start_time.elapsed();
+    observe_prepare_input_time(block_number, elapsed, true);
+    raiko.get_output(&input).expect("output generation failed");
+    Ok(axum::Json(Status::Ok {
+        data: ProofResponse {
+            input: Some(input),
+            output: None,
+        },
+    }))
+}
+
+#[derive(OpenApi)]
+#[openapi(paths(input_handler))]
+struct Docs;
+
+pub fn create_docs() -> utoipa::openapi::OpenApi {
+    Docs::openapi()
+}
+
+pub fn create_router() -> Router<Actor> {
+    Router::new().route("/", post(input_handler))
+}

--- a/host/src/server/api/v1/input.rs
+++ b/host/src/server/api/v1/input.rs
@@ -94,3 +94,29 @@ pub fn create_docs() -> utoipa::openapi::OpenApi {
 pub fn create_router() -> Router<Actor> {
     Router::new().route("/", post(input_handler))
 }
+
+#[cfg(test)]
+mod test {
+    use axum::response::IntoResponse;
+
+    #[derive(serde::Serialize, serde::Deserialize, Debug)]
+    struct JsonRef {
+        data: u128,
+    }
+
+    #[test]
+    fn test_axum_json() {
+        let json_str = serde_json::to_string(&JsonRef {
+            data: u128::MAX - 1,
+        });
+        println!("json_str = {:?}.", json_str);
+
+        let json_obj = serde_json::from_str::<JsonRef>(&json_str.unwrap());
+        println!("json_obj = {:?}.", json_obj);
+
+        let axum_json = axum::Json(JsonRef {
+            data: u128::MAX - 1,
+        });
+        println!("json_str = {:?}.", axum_json.into_response());
+    }
+}

--- a/host/src/server/api/v1/mod.rs
+++ b/host/src/server/api/v1/mod.rs
@@ -85,7 +85,7 @@ impl TryFrom<Value> for ProofResponse {
 }
 
 #[derive(Debug, Deserialize, Serialize, ToSchema)]
-#[serde(tag = "status", rename_all = "lowercase")]
+#[serde(rename_all = "lowercase")]
 #[allow(dead_code)]
 pub enum Status {
     Ok { data: ProofResponse },

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -14,7 +14,7 @@ mod no_std {
     };
 }
 
-use tracing::debug;
+use tracing::{debug, info};
 
 pub mod builder;
 pub mod consts;
@@ -148,7 +148,7 @@ impl Measurement {
 }
 
 pub fn print_duration(title: &str, duration: time::Duration) {
-    debug!(
+    info!(
         "{title}{}.{:03} seconds",
         duration.as_secs(),
         duration.subsec_millis()

--- a/script/prove-block.sh
+++ b/script/prove-block.sh
@@ -161,7 +161,7 @@ for block in $(eval echo {$rangeStart..$rangeEnd}); do
 	fi
 
 	echo "- proving block $block"
-	curl --location --request POST 'http://localhost:8080/v2/proof' \
+	curl --location --request POST 'http://localhost:8088/v1/input' \
 		--header 'Content-Type: application/json' \
 		--header 'Authorization: Bearer 4cbd753fbcbc2639de804f8ce425016a50e0ecd53db00cb5397912e83f5e570e' \
 		--data-raw "{


### PR DESCRIPTION
- [x] use raiko as a preflight engine, which exports guest input.
- [x] deploy this raiko engine with l2-node and share the same storage, so that it uses geth.ipc instead of networking.
- [x] proof generating raiko gets guest input directly from the remote raiko and run prover accordingly.

historical 100 sampled blocks experiment shows a 36+% performance gain in GKE, looks promising.