### PR TITLE
feat(raiko): pin the versions used of the risc0 tools

### DIFF
--- a/script/install.sh
+++ b/script/install.sh
@@ -61,7 +61,10 @@ if [ -z "$1" ] || [ "$1" == "risc0" ]; then
 		PROFILE=$HOME/.bashrc
 		echo ${PROFILE}
 		source ${PROFILE}
-		rzup install
+		rzup install rust 1.81.0
+		rzup install cpp 2024.1.5
+		rzup install r0vm 1.2.5
+		rzup install cargo-risczero 1.2.5
 	else
 		echo "/home/runner/.config/.risc0/bin" >> $GITHUB_PATH
 		echo $GITHUB_PATH


### PR DESCRIPTION
Running `rzup install` will install the latest versions of the Risc0 toolchain and tools. To avoid unintended breakage when new versions are released, pin them to working versions.

We want to release a new version of Rust (1.85.0) for building guests, but if we set it as latest `rzup install` will silently upgrade to it, potentially breaking compilation.