### PR TITLE
chore: use tempfile instead of memfd to cross platforms

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1755,7 +1755,7 @@ dependencies = [
  "bitflags 2.6.0",
  "cexpr",
  "clang-sys",
- "itertools 0.11.0",
+ "itertools 0.13.0",
  "log",
  "prettyplease",
  "proc-macro2",
@@ -4842,6 +4842,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
+
+[[package]]
 name = "lock_api"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5006,15 +5012,6 @@ name = "memchr"
 version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
-
-[[package]]
-name = "memfd"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2cffa4ad52c6f791f4f8b15f0c05f9824b2ced1160e88cc393d64fff9a8ac64"
-dependencies = [
- "rustix",
-]
 
 [[package]]
 name = "memmap2"
@@ -6295,7 +6292,7 @@ dependencies = [
  "hex",
  "lazy_static",
  "procfs-core",
- "rustix",
+ "rustix 0.38.43",
 ]
 
 [[package]]
@@ -6362,7 +6359,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "157c5a9d7ea5c2ed2d9fb8f495b64759f7816c7eaea54ba3978f0d63000162e3"
 dependencies = [
  "anyhow",
- "itertools 0.11.0",
+ "itertools 0.13.0",
  "proc-macro2",
  "quote",
  "syn 2.0.95",
@@ -8503,7 +8500,20 @@ dependencies = [
  "bitflags 2.6.0",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.4.14",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rustix"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c71e83d6afe7ff64890ec6b71d6a69bb8a610ab78ce364b3352876bb4c801266"
+dependencies = [
+ "bitflags 2.6.0",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.9.4",
  "windows-sys 0.59.0",
 ]
 
@@ -9041,7 +9051,6 @@ dependencies = [
  "duct",
  "env_logger",
  "hex",
- "memfd",
  "once_cell",
  "pem 3.0.4",
  "raiko-lib",
@@ -9050,6 +9059,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with 3.9.0",
+ "tempfile",
  "tokio",
  "tracing",
  "url",
@@ -10003,15 +10013,14 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tempfile"
-version = "3.15.0"
+version = "3.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a8a559c81686f576e8cd0290cd2a24a2a9ad80c98b3478856500fcbd7acd704"
+checksum = "e8a64e3985349f2441a1a9ef0b853f869006c3855f2cda6862a94d26ebb9d6a1"
 dependencies = [
- "cfg-if",
  "fastrand",
- "getrandom 0.2.15",
+ "getrandom 0.3.2",
  "once_cell",
- "rustix",
+ "rustix 1.0.7",
  "windows-sys 0.59.0",
 ]
 
@@ -11101,7 +11110,7 @@ dependencies = [
  "either",
  "home",
  "once_cell",
- "rustix",
+ "rustix 0.38.43",
 ]
 
 [[package]]

--- a/provers/sgx/prover/Cargo.toml
+++ b/provers/sgx/prover/Cargo.toml
@@ -28,7 +28,7 @@ hex = { workspace = true }
 reqwest = { workspace = true }
 reqwest_alloy = { workspace = true }
 tracing = { workspace = true }
-memfd = "0.6.4"
+tempfile = "3.20.0"
 duct = "1.0.0"
 
 [dev-dependencies]

--- a/provers/sgx/prover/src/local_prover.rs
+++ b/provers/sgx/prover/src/local_prover.rs
@@ -10,7 +10,6 @@ use std::{
 };
 
 use duct::{cmd, Expression};
-use memfd::MemfdOptions;
 use once_cell::sync::Lazy;
 use raiko_lib::{
     input::{
@@ -507,11 +506,11 @@ async fn prove(
             .stderr_capture();
 
         if proof_type == ProofType::SgxGeth {
-            let mfd = MemfdOptions::default().create("sgx-geth-witness").unwrap();
-            serde_json::to_writer(mfd.as_file(), &input)
+            let mut temp_file = tempfile::tempfile()?;
+            serde_json::to_writer(&temp_file, &input)
                 .map_err(|e| ProverError::GuestError(format!("Failed to serialize input: {e}")))?;
-            mfd.as_file().seek(std::io::SeekFrom::Start(0)).unwrap();
-            gramine_cmd = gramine_cmd.stdin_file(mfd);
+            temp_file.seek(std::io::SeekFrom::Start(0)).unwrap();
+            gramine_cmd = gramine_cmd.stdin_file(temp_file);
         } else {
             let bytes = bincode::serialize(&input)
                 .map_err(|e| ProverError::GuestError(format!("Failed to serialize input: {e}")))?;
@@ -551,11 +550,11 @@ async fn batch_prove(
             .stderr_capture();
 
         if proof_type == ProofType::SgxGeth {
-            let mfd = MemfdOptions::default().create("sgx-geth-witness").unwrap();
-            serde_json::to_writer(mfd.as_file(), &input)
+            let mut temp_file = tempfile::tempfile()?;
+            serde_json::to_writer(&temp_file, &input)
                 .map_err(|e| ProverError::GuestError(format!("Failed to serialize input: {e}")))?;
-            mfd.as_file().seek(std::io::SeekFrom::Start(0)).unwrap();
-            gramine_cmd = gramine_cmd.stdin_file(mfd);
+            temp_file.seek(std::io::SeekFrom::Start(0)).unwrap();
+            gramine_cmd = gramine_cmd.stdin_file(temp_file);
         } else {
             let bytes = bincode::serialize(&input)
                 .map_err(|e| ProverError::GuestError(format!("Failed to serialize input: {e}")))?;


### PR DESCRIPTION
only linux supports memfd, we can use "Anonymous" tempfile instead of it