### PR TITLE
chore: fix confusing log and missing status checks

### DIFF
--- a/reqactor/src/backend.rs
+++ b/reqactor/src/backend.rs
@@ -444,8 +444,8 @@ impl Backend {
             .unwrap()
             .unwrap()
             .into_status();
-        if matches!(pool_status, Status::Success { .. } | Status::WorkInProgress) {
-            tracing::warn!("Actor Backend received prove-action {request_key}, but it is not registered, skipping");
+        if matches!(pool_status, Status::Success { .. } | Status::WorkInProgress | Status::Failed { .. } | Status::Cancelled { .. }) {
+            tracing::warn!("Actor Backend received prove-action {request_key}, but it is already in status {:?}, skipping", pool_status);
             return;
         }
 


### PR DESCRIPTION
spotted a log message that didn’t match what was actually happening - it said something wasn’t registered, but it was really just checking for `Success` or `WorkInProgress`. that was throwing me off when reading logs.

p.s. also added checks for `Failed` and `Cancelled` statuses since those were getting ignored but can matter too.
