### PR TITLE
Fix Bonsai script reference in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ TARGET=risc0 make test
 
 #### Bonsai
 
-If you are using the Bonsai service, edit `run-bonsai.sh` to setup your API key, endpoint, and on-chain verifier address.
+If you are using the Bonsai service, edit `script/setup-bonsai.sh` to setup your API key, endpoint, and on-chain verifier address.
 
 ```shell
 ./script/setup-bonsai.sh


### PR DESCRIPTION


---


**Description:**  
- Updated the Bonsai service setup instructions in the README  
- Replaced the outdated `run-bonsai.sh` reference with the correct `script/setup-bonsai.sh`  
- Improved clarity for new users

---