### PR TITLE
feat: add a maximum queue size limit

### DIFF
--- a/host/src/bin/main.rs
+++ b/host/src/bin/main.rs
@@ -37,6 +37,7 @@ async fn main() -> HostResult<()> {
         chain_specs.clone(),
         default_request_config.clone(),
         max_proving_concurrency,
+        opts.queue_limit,
     )
     .await;
 

--- a/host/src/lib.rs
+++ b/host/src/lib.rs
@@ -84,6 +84,11 @@ pub struct Opts {
     #[arg(long, default_value = "false")]
     pub enable_redis_pool: bool,
 
+    #[arg(long, require_equals = true, default_value = "1000")]
+    #[serde(default = "Opts::default_queue_limit")]
+    /// Limit the max number of requests in the queue (including in-progress)
+    pub queue_limit: usize,
+
     /// supported API keys hashset, now using input for simplicity
     #[arg(
         long,
@@ -122,6 +127,10 @@ impl Opts {
 
     fn default_log_level() -> String {
         "info".to_string()
+    }
+
+    fn default_queue_limit() -> usize {
+        1000
     }
 
     /// Read the options from a file and merge it with the current options.

--- a/host/tests/common/server.rs
+++ b/host/tests/common/server.rs
@@ -58,6 +58,7 @@ impl TestServerBuilder {
             chain_specs.clone(),
             default_request_config.clone(),
             max_proving_concurrency,
+            1000, // max_queue_size
         )
         .await;
 

--- a/reqactor/src/actor.rs
+++ b/reqactor/src/actor.rs
@@ -220,7 +220,7 @@ mod tests {
         let ballot = Ballot::new(BTreeMap::new()).unwrap();
         let default_request_config = ProofRequestOpt::default();
         let chain_specs = SupportedChainSpecs::default();
-        let queue = Arc::new(Mutex::new(Queue::new()));
+        let queue = Arc::new(Mutex::new(Queue::new(1000)));
         let notify = Arc::new(Notify::new());
 
         Actor::new(

--- a/reqactor/src/backend.rs
+++ b/reqactor/src/backend.rs
@@ -480,7 +480,7 @@ mod tests {
     async fn test_serve_in_background() {
         let pool = create_test_pool();
         let chain_specs = create_test_chain_specs();
-        let queue = Arc::new(Mutex::new(Queue::new()));
+        let queue = Arc::new(Mutex::new(Queue::new(1000)));
         let notifier = Arc::new(Notify::new());
 
         let backend = Backend::new(pool, chain_specs, 1, queue.clone(), notifier.clone());

--- a/reqactor/src/lib.rs
+++ b/reqactor/src/lib.rs
@@ -27,8 +27,9 @@ pub async fn start_actor(
     chain_specs: SupportedChainSpecs,
     default_request_config: ProofRequestOpt,
     max_proving_concurrency: usize,
+    max_queue_size: usize,
 ) -> Actor {
-    let queue = Arc::new(Mutex::new(Queue::new()));
+    let queue = Arc::new(Mutex::new(Queue::new(max_queue_size)));
     let notify = Arc::new(Notify::new());
     let actor = Actor::new(
         pool.clone(),

--- a/reqactor/src/queue.rs
+++ b/reqactor/src/queue.rs
@@ -44,11 +44,6 @@ impl Queue {
         self.queued_keys.len()
     }
 
-    /// Get the maximum queue size
-    pub fn max_size(&self) -> usize {
-        self.max_queue_size
-    }
-
     pub fn add_pending(&mut self, request_key: RequestKey, request_entity: RequestEntity) -> Result<(), String> {
         // Check if queue is at capacity
         if self.is_at_capacity() {


### PR DESCRIPTION
Add a maximum queue size limit with a default value of 1000 to the Queue struct, now the actor will return a failed status when the queue is full.