### PR TITLE
ci: bump actions/checkout to v5

### DIFF
--- a/.github/workflows/ci-all.yml
+++ b/.github/workflows/ci-all.yml
@@ -43,7 +43,7 @@ jobs:
     timeout-minutes: 60
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: actions-rs/toolchain@v1
         with:

--- a/.github/workflows/ci-build-test-reusable.yml
+++ b/.github/workflows/ci-build-test-reusable.yml
@@ -27,7 +27,7 @@ jobs:
       MOCK: 1
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           submodules: recursive
 

--- a/.github/workflows/ci-integration-reusable.yml
+++ b/.github/workflows/ci-integration-reusable.yml
@@ -29,7 +29,7 @@ jobs:
       MOCK: 1
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           submodules: recursive
       

--- a/.github/workflows/ci-lint.yml
+++ b/.github/workflows/ci-lint.yml
@@ -18,7 +18,7 @@ jobs:
     timeout-minutes: 30
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Run install script for all targets
         run: make install
@@ -32,7 +32,7 @@ jobs:
     timeout-minutes: 10
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Run format script for all targets
         run: make fmt

--- a/.github/workflows/ci-sgx-docker.yml
+++ b/.github/workflows/ci-sgx-docker.yml
@@ -20,7 +20,7 @@ jobs:
     timeout-minutes: 60
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           submodules: true 
       - name: Setup and build sgx docker

--- a/.github/workflows/ci-sgx-hardware.yml
+++ b/.github/workflows/ci-sgx-hardware.yml
@@ -14,7 +14,7 @@ jobs:
       EDMM: 0
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           submodules: recursive
 

--- a/.github/workflows/openapi-deploy.yml
+++ b/.github/workflows/openapi-deploy.yml
@@ -29,7 +29,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Rust
         uses: actions-rs/toolchain@v1

--- a/.github/workflows/repo--typo-check.yml
+++ b/.github/workflows/repo--typo-check.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: [taiko-runner]
     steps:
       - name: Checkout the repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Check for typos
         uses: crate-ci/typos@master


### PR DESCRIPTION
GitHub-hosted runners now use Node 24, so actions/checkout@v5 is required. Minimum runner version v2.327.1. Workflows only updated—no functional changes.

See: https://github.com/actions/checkout/releases/tag/v5.0.0