### PR TITLE
Update GitHub Action to configure-pages@v5

### DIFF
--- a/.github/workflows/openapi-deploy.yml
+++ b/.github/workflows/openapi-deploy.yml
@@ -42,7 +42,7 @@ jobs:
 
       - name: Setup Pages
         if: github.ref == 'refs/heads/main'
-        uses: actions/configure-pages@v3
+        uses: actions/configure-pages@v5
 
       - name: Upload artifact
         if: github.ref == 'refs/heads/main'


### PR DESCRIPTION
uses: actions/configure-pages@v3 -> uses: actions/configure-pages@v5

Version v5 provides enhanced performance, updated security measures, and improved support for GitHub Pages deployments.
 Release notes: https://github.com/actions/configure-pages/releases/tag/v5.0.0