### PR TITLE
fix(lib): thread proposal_id and chain_id into ShastaData for anchor skip

### DIFF
--- a/lib/src/builder.rs
+++ b/lib/src/builder.rs
@@ -64,7 +64,8 @@ pub fn calculate_batch_blocks_final_header(input: &GuestBatchInput) -> Vec<Block
             &input.inputs[i],
             create_mem_db(&mut input.inputs[i].clone()).unwrap(),
         )
-        .set_is_first_block_in_proposal(i == 0);
+        .set_is_first_block_in_proposal(i == 0)
+        .set_proposal_id(input.taiko.batch_id);
 
         let mut execute_tx = vec![input.inputs[i].taiko.anchor_tx.clone().unwrap()];
         execute_tx.extend_from_slice(&pool_txs.0);
@@ -142,6 +143,8 @@ pub struct RethBlockBuilder<DB> {
     pub db: Option<DB>,
     /// Whether this is the first block in a proposal batch (for Shasta)
     pub is_first_block_in_proposal: bool,
+    /// The proposal (batch) ID, used to skip anchor checks for early mainnet proposals.
+    pub proposal_id: u64,
 }
 
 impl<DB: Database<Error = ProviderError> + DatabaseCommit + OptimisticDatabase>
@@ -156,12 +159,19 @@ impl<DB: Database<Error = ProviderError> + DatabaseCommit + OptimisticDatabase>
             db: Some(db),
             input: input.clone(),
             is_first_block_in_proposal: true, // Default to true for single block execution
+            proposal_id: 0,
         }
     }
 
     /// Sets whether this is the first block in a proposal batch.
     pub fn set_is_first_block_in_proposal(mut self, is_first: bool) -> Self {
         self.is_first_block_in_proposal = is_first;
+        self
+    }
+
+    /// Sets the proposal (batch) ID for anchor check overrides.
+    pub fn set_proposal_id(mut self, proposal_id: u64) -> Self {
+        self.proposal_id = proposal_id;
         self
     }
 
@@ -258,6 +268,8 @@ impl<DB: Database<Error = ProviderError> + DatabaseCommit + OptimisticDatabase>
                 last_anchor_block_number: last_anchor_block_number_opt.unwrap(),
                 is_force_inclusion: *is_force_inclusion,
                 is_first_block_in_proposal: self.is_first_block_in_proposal,
+                proposal_id: self.proposal_id,
+                chain_id: self.input.chain_spec.chain_id,
             })
         } else {
             None


### PR DESCRIPTION
## Summary

- Add `proposal_id` field to `RethBlockBuilder` and thread `batch_id` through to `ShastaData`
- Add `chain_id` from `ChainSpec` to `ShastaData`
- These fields enable taiko-reth to conditionally skip the anchor success check for early mainnet Shasta proposals (1-7) where `anchorV4()` reverted during bootstrapping

## Context

The first Shasta proposals on mainnet had reverted anchor transactions due to bootstrapping issues. The prover cannot generate valid proofs for these proposals because the consensus rule "anchor tx must succeed" fails. This change passes the proposal ID and chain ID through to the execution layer so it can make a targeted exception for those specific proposals.

## Companion PRs

- **taiko-reth**: [taikoxyz/taiko-reth#73](https://github.com/taikoxyz/taiko-reth/pull/73) — the execution-layer change that conditionally skips the anchor check
- **taiko-mono**: [taikoxyz/taiko-mono#21529](https://github.com/taikoxyz/taiko-mono/pull/21529) — client-side driver fix for reading anchor state during bootstrapping

## Note

Once taiko-reth#73 is merged, this PR's `Cargo.toml` should be updated to point `reth-*` dependencies to the merged branch (or `v1.0.0-rc.2-taiko-shasta` if it's merged there).

## Test plan

- [ ] Verify raiko compiles with updated taiko-reth dependency
- [ ] Generate proof for mainnet proposal 1-7 and verify success
- [ ] Generate proof for proposal >= 8 and verify anchor check still enforced
- [ ] End-to-end proof submission to Inbox.prove()

🤖 Generated with [Claude Code](https://claude.com/claude-code)