### PR TITLE
fix: correct typos in SGX prover error messages

### DIFF
--- a/provers/sgx/guest/src/main.rs
+++ b/provers/sgx/guest/src/main.rs
@@ -40,7 +40,7 @@ pub async fn main() -> Result<()> {
         Command::Check => {
             println!("Checking if bootstrap is readable");
             load_bootstrap(&args.global_opts.secrets_dir)
-                .map_err(|err| anyhow!("check booststrap failed: {err}"))?;
+                .map_err(|err| anyhow!("check bootstrap failed: {err}"))?;
         }
         Command::Serve(server_args) => {
             println!("Sgx proof server");

--- a/provers/sgx/prover/src/local_prover.rs
+++ b/provers/sgx/prover/src/local_prover.rs
@@ -380,7 +380,7 @@ async fn setup(cur_dir: &Path, direct_mode: bool) -> ProverResult<(), String> {
         .arg("sgx-guest.manifest")
         .output()
         .await
-        .map_err(|e| handle_gramine_error("Could not generate manfifest", e))?;
+        .map_err(|e| handle_gramine_error("Could not generate manifest", e))?;
     handle_output(&output, "SGX generate manifest")?;
 
     if !direct_mode {
@@ -404,7 +404,7 @@ async fn setup(cur_dir: &Path, direct_mode: bool) -> ProverResult<(), String> {
             .arg("sgx-guest.manifest.sgx")
             .output()
             .await
-            .map_err(|e| handle_gramine_error("Could not sign manfifest", e))?;
+            .map_err(|e| handle_gramine_error("Could not sign manifest", e))?;
         handle_output(&output, "SGX manifest sign")?;
     }
 


### PR DESCRIPTION
Fix typos in error messages:
- `manfifest` → `manifest` (local_prover.rs, 2 occurrences)  
- `booststrap` → `bootstrap` (main.rs)