### PR TITLE
fix: harden Shasta guest soundness checks

### DIFF
--- a/core/src/preflight/mod.rs
+++ b/core/src/preflight/mod.rs
@@ -293,6 +293,10 @@ pub async fn batch_preflight<BDP: BlockDataProvider>(
                 block: block.clone(),
                 parent_header: parent_block.header.clone().try_into().unwrap(),
                 chain_spec: taiko_chain_spec.clone(),
+                taiko: TaikoGuestInput {
+                    anchor_tx: block.body.first().cloned(),
+                    ..Default::default()
+                },
                 ..Default::default()
             })
             .collect(),

--- a/host/config/chain_spec_list_devnet.json
+++ b/host/config/chain_spec_list_devnet.json
@@ -68,10 +68,10 @@
         "beacon_rpc": null,
         "verifier_address_forks": {
             "SHASTA": {
-                "SGX": "0x6fF4A33Fe3766D08251247Daab78F7ebEAD7Db72",
+                "SGX": "0x25A669bc4E405b78437B560f908bc78F8141d159",
                 "SP1": "0xCb2D625BF8C2187B180646aF4738AF5F1413Fb70",
                 "RISC0": "0x48940F7ab2C674Aa66C09eDa71614aD704E9d007",
-                "SGXGETH": "0xb31e61a8b6Fb5A9573dC1a0B328b1BD184dca98E"
+                "SGXGETH": "0xFCA057AB211Dfaeb01FB8a36F4231Fb4021a6641"
             }
         },
         "genesis_time": 0,

--- a/host/config/chain_spec_list_devnet.json
+++ b/host/config/chain_spec_list_devnet.json
@@ -40,19 +40,9 @@
         "chain_id": 167001,
         "max_spec_id": "SHASTA",
         "hard_forks": {
-            "HEKLA": {
-                "Block": 0
-            },
-            "ONTAKE": {
-                "Block": 0
-            },
-            "PACAYA": {
-                "Block": 0
-            },
             "SHASTA": {
                 "Timestamp": 0
-            },
-            "CANCUN": "TBD"
+            }
         },
         "eip_1559_constants": {
             "base_fee_change_denominator": "0x8",

--- a/host/src/server/api/v3/proof/shasta_handler.rs
+++ b/host/src/server/api/v3/proof/shasta_handler.rs
@@ -113,8 +113,7 @@ async fn shasta_batch_handler(
     ) = process_shasta_batch(&shasta_request, &image_id);
 
     // Run input step first to reuse cached guest input (both aggregate and non-aggregate)
-    let statuses =
-        prove_many(&actor, sub_input_request_keys, sub_input_request_entities).await?;
+    let statuses = prove_many(&actor, sub_input_request_keys, sub_input_request_entities).await?;
     let is_all_sub_success = statuses
         .iter()
         .all(|status| matches!(status, raiko_reqpool::Status::Success { .. }));

--- a/lib/src/builder.rs
+++ b/lib/src/builder.rs
@@ -30,6 +30,14 @@ use reth_primitives::{
 };
 use tracing::{debug, error};
 
+fn assert_shasta_taiko_fork(taiko_fork: SpecId) {
+    assert_eq!(
+        taiko_fork,
+        SpecId::SHASTA,
+        "only SHASTA fork is supported, got {taiko_fork:?}"
+    );
+}
+
 pub fn calculate_block_header(input: &GuestInput) -> Header {
     let cycle_tracker = CycleTracker::start("initialize_database");
     let db = create_mem_db(&mut input.clone()).unwrap();
@@ -201,42 +209,14 @@ impl<DB: Database<Error = ProviderError> + DatabaseCommit + OptimisticDatabase>
         let block_ts = self.input.block.timestamp;
         let taiko_fork = self.input.chain_spec.spec_id(block_num, block_ts).unwrap();
         if reth_chain_spec.is_taiko() {
-            match taiko_fork {
-                SpecId::HEKLA => {
-                    assert!(
-                        reth_chain_spec
-                            .fork(Hardfork::Hekla)
-                            .active_at_block(block_num),
-                        "evm fork HEKLA is not active, please update the chain spec"
-                    );
-                }
-                SpecId::ONTAKE => {
-                    assert!(
-                        reth_chain_spec
-                            .fork(Hardfork::Ontake)
-                            .active_at_block(block_num),
-                        "evm fork ONTAKE is not active, please update the chain spec"
-                    );
-                }
-                SpecId::PACAYA => {
-                    assert!(
-                        reth_chain_spec
-                            .fork(Hardfork::Pacaya)
-                            .active_at_block(block_num),
-                        "evm fork PACAYA is not active, please update the chain spec"
-                    );
-                }
-                SpecId::SHASTA => {
-                    // shasta is activated by timestamp, not block number
-                    assert!(
-                        reth_chain_spec
-                            .fork(Hardfork::Shasta)
-                            .active_at_timestamp(block_ts),
-                        "evm fork SHASTA is not active, please update the chain spec"
-                    );
-                }
-                _ => unimplemented!(),
-            }
+            assert_shasta_taiko_fork(taiko_fork);
+            // Shasta is activated by timestamp, not block number.
+            assert!(
+                reth_chain_spec
+                    .fork(Hardfork::Shasta)
+                    .active_at_timestamp(block_ts),
+                "evm fork SHASTA is not active, please update the chain spec"
+            );
         }
 
         // Generate the transactions from the tx list
@@ -551,4 +531,28 @@ pub fn create_mem_db(input: &mut GuestInput) -> Result<MemDb> {
         accounts,
         block_hashes,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn shasta_fork_guard_accepts_shasta() {
+        assert_shasta_taiko_fork(SpecId::SHASTA);
+    }
+
+    #[test]
+    fn shasta_fork_guard_rejects_legacy_forks() {
+        for legacy_fork in [SpecId::HEKLA, SpecId::ONTAKE, SpecId::PACAYA] {
+            let panic = std::panic::catch_unwind(|| assert_shasta_taiko_fork(legacy_fork))
+                .expect_err("legacy fork should be rejected");
+            let message = panic
+                .downcast_ref::<String>()
+                .map(String::as_str)
+                .or_else(|| panic.downcast_ref::<&str>().copied())
+                .unwrap_or_default();
+            assert!(message.contains("only SHASTA fork is supported"));
+        }
+    }
 }

--- a/lib/src/protocol_instance.rs
+++ b/lib/src/protocol_instance.rs
@@ -506,21 +506,40 @@ fn verify_shasha_anchor_linkage(
 }
 
 fn bypass_shasta_anchor_linkage(batch_input: &GuestBatchInput) -> bool {
-    if !batch_input.taiko.l1_ancestor_headers.is_empty() {
+    let mut anchor_block_numbers = Vec::with_capacity(batch_input.inputs.len());
+    for input in &batch_input.inputs {
+        let Some(anchor_tx) = input.taiko.anchor_tx.as_ref() else {
+            error!("cannot bypass shasta anchor linkage: missing anchor tx");
+            return false;
+        };
+        let std::result::Result::Ok(anchor_data) = decode_anchor_shasta(anchor_tx.input()) else {
+            error!("cannot bypass shasta anchor linkage: failed to decode anchor tx");
+            return false;
+        };
+        anchor_block_numbers.push(anchor_data._checkpoint.blockNumber);
+    }
+
+    is_stalled_anchor_bypass_allowed(
+        batch_input.taiko.l1_ancestor_headers.is_empty(),
+        batch_input.taiko.prover_data.last_anchor_block_number,
+        &anchor_block_numbers,
+    )
+}
+
+fn is_stalled_anchor_bypass_allowed(
+    l1_ancestor_headers_empty: bool,
+    last_anchor_block_number: Option<u64>,
+    anchor_block_numbers: &[u64],
+) -> bool {
+    if !l1_ancestor_headers_empty || anchor_block_numbers.is_empty() {
         return false;
     }
-    let mut anchors = batch_input.inputs.iter().filter_map(|input| {
-        input
-            .taiko
-            .anchor_tx
-            .as_ref()
-            .and_then(|tx| decode_anchor_shasta(tx.input()).ok())
-            .map(|data| data._checkpoint.blockNumber)
-    });
-    let Some(first_anchor) = anchors.next() else {
+    let Some(last_anchor_block_number) = last_anchor_block_number else {
         return false;
     };
-    anchors.all(|h| h == first_anchor)
+    anchor_block_numbers
+        .iter()
+        .all(|anchor_block_number| *anchor_block_number == last_anchor_block_number)
 }
 
 impl ProtocolInstance {
@@ -1110,6 +1129,28 @@ mod tests {
                 0, 0, 0, 0
             ]
         );
+    }
+
+    #[test]
+    fn stalled_anchor_bypass_requires_last_anchor_match() {
+        assert!(is_stalled_anchor_bypass_allowed(
+            true,
+            Some(100),
+            &[100, 100]
+        ));
+        assert!(!is_stalled_anchor_bypass_allowed(
+            true,
+            Some(100),
+            &[101, 101]
+        ));
+        assert!(!is_stalled_anchor_bypass_allowed(
+            true,
+            Some(100),
+            &[100, 101]
+        ));
+        assert!(!is_stalled_anchor_bypass_allowed(false, Some(100), &[100]));
+        assert!(!is_stalled_anchor_bypass_allowed(true, None, &[100]));
+        assert!(!is_stalled_anchor_bypass_allowed(true, Some(100), &[]));
     }
 
     #[test]

--- a/lib/src/utils/shasta.rs
+++ b/lib/src/utils/shasta.rs
@@ -160,7 +160,7 @@ pub fn generate_transactions_for_shasta_blocks(
                     assert!(
                         validate_input_block_param(
                             block_manifest,
-                            &guest_batch_input.inputs[idx + offset].block
+                            &guest_batch_input.inputs[idx + offset]
                         ),
                         "input block manifest is invalid"
                     );
@@ -211,7 +211,7 @@ pub fn generate_transactions_for_shasta_blocks(
             assert!(
                 validate_input_block_param(
                     force_inc_block_manifest,
-                    &guest_batch_input.inputs[idx].block
+                    &guest_batch_input.inputs[idx]
                 ),
                 "force inclusion source is invalid"
             );

--- a/lib/src/utils/shasta_rules.rs
+++ b/lib/src/utils/shasta_rules.rs
@@ -1,7 +1,7 @@
 use core::cmp::{max, min};
-use reth_evm_ethereum::taiko::ANCHOR_V4_GAS_LIMIT;
+use reth_evm_ethereum::taiko::{decode_anchor_shasta, ANCHOR_V4_GAS_LIMIT};
 use reth_primitives::revm_primitives::SpecId;
-use reth_primitives::{Block, Header};
+use reth_primitives::Header;
 use std::cmp::max as std_max;
 use tracing::{info, warn};
 
@@ -244,8 +244,9 @@ pub(crate) fn validate_force_inc_proposal_manifest(manifest: &DerivationSourceMa
 
 pub(crate) fn validate_input_block_param(
     manifest_block: &ProtocolBlockManifest,
-    input_block: &Block,
+    input: &GuestInput,
 ) -> bool {
+    let input_block = &input.block;
     if manifest_block.timestamp != input_block.header.timestamp {
         warn!(
             "manifest_block.timestamp != input_block.header.timestamp, manifest_block.timestamp: {}, input_block.header.timestamp: {}",
@@ -264,6 +265,32 @@ pub(crate) fn validate_input_block_param(
         warn!(
             "manifest_block.gas_limit != input_block.header.gas_limit, manifest_block.gas_limit: {}, input_block.header.gas_limit: {}",
             manifest_block.gas_limit, input_block.header.gas_limit
+        );
+        return false;
+    }
+    let Some(anchor_tx) = &input.taiko.anchor_tx else {
+        warn!("input block missing shasta anchor tx");
+        return false;
+    };
+    if !validate_shasta_anchor_tx_for_manifest_block(manifest_block, anchor_tx.input()) {
+        return false;
+    }
+    true
+}
+
+fn validate_shasta_anchor_tx_for_manifest_block(
+    manifest_block: &ProtocolBlockManifest,
+    anchor_tx_input: &[u8],
+) -> bool {
+    let Ok(anchor_data) = decode_anchor_shasta(anchor_tx_input) else {
+        warn!("failed to decode shasta anchor tx calldata");
+        return false;
+    };
+    if anchor_data._checkpoint.blockNumber != manifest_block.anchor_block_number {
+        warn!(
+            "manifest_block.anchor_block_number != anchor_tx checkpoint blockNumber, manifest_block.anchor_block_number: {}, anchor_tx checkpoint blockNumber: {}",
+            manifest_block.anchor_block_number,
+            anchor_data._checkpoint.blockNumber
         );
         return false;
     }
@@ -664,12 +691,25 @@ mod tests {
         BlockProposedFork, GuestBatchInput, GuestInput, TaikoGuestBatchInput,
     };
     use crate::manifest::{DerivationSourceManifest, ProtocolBlockManifest};
-    use alloy_primitives::B256;
+    use alloy_primitives::{Address, B256};
+    use alloy_sol_types::SolCall;
+    use reth_evm_ethereum::taiko::{anchorV4Call, Checkpoint};
     use reth_primitives::revm_primitives::SpecId;
     use reth_primitives::Header;
     use std::collections::BTreeMap;
 
     use super::calc_next_shasta_base_fee;
+
+    fn shasta_anchor_input(anchor_block_number: u64) -> Vec<u8> {
+        anchorV4Call {
+            _checkpoint: Checkpoint {
+                blockNumber: anchor_block_number,
+                blockHash: B256::ZERO,
+                stateRoot: B256::ZERO,
+            },
+        }
+        .abi_encode()
+    }
 
     fn base_fee_guest_input(parent_header: Header, block_base_fee: u64) -> GuestInput {
         let mut input = GuestInput {
@@ -678,6 +718,30 @@ mod tests {
         };
         input.block.header.base_fee_per_gas = Some(block_base_fee);
         input
+    }
+
+    #[test]
+    fn validate_shasta_anchor_tx_for_manifest_block_rejects_anchor_mismatch() {
+        let manifest_block = ProtocolBlockManifest {
+            timestamp: 100,
+            coinbase: Address::ZERO,
+            anchor_block_number: 100,
+            gas_limit: 20_000_000,
+            transactions: Vec::new(),
+        };
+
+        assert!(!super::validate_shasta_anchor_tx_for_manifest_block(
+            &manifest_block,
+            &shasta_anchor_input(101)
+        ));
+        assert!(super::validate_shasta_anchor_tx_for_manifest_block(
+            &manifest_block,
+            &shasta_anchor_input(100)
+        ));
+        assert!(!super::validate_shasta_anchor_tx_for_manifest_block(
+            &manifest_block,
+            b"not-anchor-calldata"
+        ));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Restrict Taiko guest block execution to the Shasta fork in `RethBlockBuilder::execute_transactions`, removing legacy HEKLA/ONTAKE/PACAYA fork-choice paths from the hotfix execution path.
- Bind each Shasta manifest block's `anchor_block_number` to the decoded anchor tx checkpoint block number.
- Tighten stalled-anchor linkage bypass so it only applies when all decoded anchors equal `last_anchor_block_number` and ancestor headers are empty.
- Update devnet Shasta SGX verifier addresses to the current SGX and SGXGETH verifier contracts.

## Test Plan

- `python3 - <<'PY' ...` JSON/address validation for `host/config/chain_spec_list_devnet.json`
- `cargo test -p raiko-lib shasta_fork_guard --lib`
- `cargo fmt --package raiko-lib --check`
- `cargo test -p raiko-lib --lib` (`53 passed; 2 ignored`)
