### PR TITLE
fix: port Shasta hotfix soundness checks to main

### DIFF
--- a/core/src/preflight/mod.rs
+++ b/core/src/preflight/mod.rs
@@ -117,6 +117,10 @@ pub async fn batch_preflight<BDP: BlockDataProvider>(
                 block: block.clone(),
                 parent_header: parent_block.header.clone().try_into().unwrap(),
                 chain_spec: taiko_chain_spec.clone(),
+                taiko: TaikoGuestInput {
+                    anchor_tx: block.body.first().cloned(),
+                    ..Default::default()
+                },
                 ..Default::default()
             })
             .collect(),

--- a/core/src/preflight/mod.rs
+++ b/core/src/preflight/mod.rs
@@ -17,6 +17,9 @@ use raiko_lib::{
         TaikoProverData,
     },
     primitives::mpt::proofs_to_tries,
+    protocol_instance::{
+        shasta_checkpoint_storage_slots, shasta_signal_service_address_from_l2_contract,
+    },
     utils::txs::generate_transactions_for_batch_blocks,
     Measurement,
 };
@@ -44,6 +47,36 @@ pub struct BatchPreflightData {
     pub blob_proof_type: BlobProofType,
     /// Cached event data to avoid duplicate RPC calls
     pub cached_event_data: Option<raiko_lib::input::BlockProposedFork>,
+}
+
+fn shasta_parent_checkpoint_storage_slots(
+    input: &GuestInput,
+) -> RaikoResult<Vec<(raiko_lib::primitives::Address, raiko_lib::primitives::U256)>> {
+    let Some(last_anchor_block_number) = input.taiko.prover_data.last_anchor_block_number else {
+        return Err(RaikoError::Preflight(
+            "cannot load shasta parent checkpoint: missing last_anchor_block_number".to_owned(),
+        ));
+    };
+    let Some(signal_service) =
+        shasta_signal_service_address_from_l2_contract(input.chain_spec.l2_contract)
+    else {
+        return Err(RaikoError::Preflight(
+            "cannot load shasta parent checkpoint: invalid l2 contract address".to_owned(),
+        ));
+    };
+    let (block_hash_slot, state_root_slot) =
+        shasta_checkpoint_storage_slots(last_anchor_block_number);
+    Ok(vec![
+        (signal_service, block_hash_slot),
+        (signal_service, state_root_slot),
+    ])
+}
+
+fn should_load_shasta_parent_checkpoint_storage(
+    input: &GuestInput,
+    _batch_block_idx: usize,
+) -> bool {
+    matches!(input.taiko.block_proposed, BlockProposedFork::Shasta(_))
 }
 
 pub async fn batch_preflight<BDP: BlockDataProvider>(
@@ -162,13 +195,19 @@ pub async fn batch_preflight<BDP: BlockDataProvider>(
         .cloned()
         .zip(pool_txs_list.iter().cloned())
         .collect();
+    let mut batch_block_offset: usize = 0;
     for task_batch in tasks.chunks(chunk_size) {
+        let batch_start_idx = batch_block_offset;
+        batch_block_offset += task_batch.len();
         let task_batch_vec = task_batch.to_vec();
         let taiko_guest_batch_input = taiko_guest_batch_input.clone();
         let taiko_chain_spec = taiko_chain_spec.clone();
         let handle = tokio::spawn(async move {
             let mut chunk_guest_input = Vec::new();
-            for ((prove_block, parent_block), txs_with_force_inc_flag) in task_batch_vec {
+            for (local_i, ((prove_block, parent_block), txs_with_force_inc_flag)) in
+                task_batch_vec.into_iter().enumerate()
+            {
+                let batch_block_idx = batch_start_idx + local_i;
                 let taiko_chain_spec = taiko_chain_spec.clone();
                 let taiko_guest_batch_input = taiko_guest_batch_input.clone();
 
@@ -251,6 +290,18 @@ pub async fn batch_preflight<BDP: BlockDataProvider>(
                     return Err(RaikoError::Preflight("No db in builder".to_owned()));
                 };
 
+                if should_load_shasta_parent_checkpoint_storage(&input, batch_block_idx) {
+                    let checkpoint_slots = shasta_parent_checkpoint_storage_slots(&input)?;
+                    db.load_initial_storage_values(&checkpoint_slots)
+                        .await
+                        .map_err(|e| {
+                            RaikoError::Preflight(format!(
+                                "failed to load shasta parent checkpoint storage at block {}: {e:?}",
+                                db.block_number
+                            ))
+                        })?;
+                }
+
                 // Gather inclusion proofs for the initial and final state
                 let measurement = Measurement::start("Fetching storage proofs...", true);
                 let (parent_proofs, current_proofs, num_storage_proofs) = db.get_proofs().await?;
@@ -331,10 +382,24 @@ mod test {
     use ethers_core::types::Transaction;
     use raiko_lib::{
         consts::{Network, SupportedChainSpecs},
+        input::{BlockProposedFork, GuestInput},
         utils::txs::decode_transactions,
     };
 
+    use super::should_load_shasta_parent_checkpoint_storage;
     use crate::preflight::util::{blob_to_bytes, block_time_to_block_slot};
+
+    #[test]
+    fn shasta_parent_checkpoint_storage_is_loaded_for_every_batch_block() {
+        let mut input = GuestInput::default();
+        input.taiko.block_proposed = BlockProposedFork::Shasta(Default::default());
+
+        assert!(should_load_shasta_parent_checkpoint_storage(&input, 0));
+        assert!(should_load_shasta_parent_checkpoint_storage(&input, 1));
+
+        input.taiko.block_proposed = BlockProposedFork::Nothing;
+        assert!(!should_load_shasta_parent_checkpoint_storage(&input, 0));
+    }
 
     #[test]
     fn test_new_blob_decode() {

--- a/core/src/provider/db.rs
+++ b/core/src/provider/db.rs
@@ -138,6 +138,55 @@ impl<'a, BDP: BlockDataProvider> ProviderDb<'a, BDP> {
         Ok((initial_proofs, latest_proofs, num_storage_proofs))
     }
 
+    pub async fn load_initial_storage_values(
+        &mut self,
+        slots: &[(Address, U256)],
+    ) -> RaikoResult<()> {
+        if slots.is_empty() {
+            return Ok(());
+        }
+
+        let mut addresses = slots
+            .iter()
+            .map(|(address, _)| *address)
+            .collect::<Vec<_>>();
+        addresses.sort_unstable();
+        addresses.dedup();
+
+        let accounts = self
+            .provider
+            .get_accounts(self.block_number, &addresses)
+            .await?;
+        if accounts.len() != addresses.len() {
+            return Err(RaikoError::RPC(format!(
+                "expected {} accounts, got {}",
+                addresses.len(),
+                accounts.len()
+            )));
+        }
+        for (address, account) in addresses.into_iter().zip(accounts) {
+            self.initial_db.insert_account_info(address, account);
+        }
+
+        let values = self
+            .provider
+            .get_storage_values(self.block_number, slots)
+            .await?;
+        if values.len() != slots.len() {
+            return Err(RaikoError::RPC(format!(
+                "expected {} storage values, got {}",
+                slots.len(),
+                values.len()
+            )));
+        }
+        for ((address, slot), value) in slots.iter().zip(values) {
+            self.initial_db
+                .insert_account_storage(address, *slot, value);
+        }
+
+        Ok(())
+    }
+
     pub async fn get_ancestor_headers(&mut self) -> RaikoResult<Vec<Header>> {
         let earliest_block = &self.block_number.saturating_sub(255);
         let mut headers = Vec::with_capacity(

--- a/host/config/chain_spec_list_devnet.json
+++ b/host/config/chain_spec_list_devnet.json
@@ -40,19 +40,9 @@
         "chain_id": 167001,
         "max_spec_id": "SHASTA",
         "hard_forks": {
-            "HEKLA": {
-                "Block": 0
-            },
-            "ONTAKE": {
-                "Block": 0
-            },
-            "PACAYA": {
-                "Block": 0
-            },
             "SHASTA": {
-                "Timestamp": 1769396301
-            },
-            "CANCUN": "TBD"
+                "Timestamp": 0
+            }
         },
         "eip_1559_constants": {
             "base_fee_change_denominator": "0x8",
@@ -68,17 +58,11 @@
         "rpc": "https://rpc.internal.taiko.xyz",
         "beacon_rpc": null,
         "verifier_address_forks": {
-            "PACAYA": {
-                "SGX": "0x9D351F6E72e3095F24dD854c9B8CA69F99A2C538",
-                "SP1": "0xCb2D625BF8C2187B180646aF4738AF5F1413Fb70",
-                "RISC0": "0x48940F7ab2C674Aa66C09eDa71614aD704E9d007",
-                "SGXGETH": "0x6B455442C8C4cAC2e09c40409E8bf7FfcdB1Fc50"
-            },
             "SHASTA": {
-                "SGX": "0x9D351F6E72e3095F24dD854c9B8CA69F99A2C538",
+                "SGX": "0x25A669bc4E405b78437B560f908bc78F8141d159",
                 "SP1": "0xCb2D625BF8C2187B180646aF4738AF5F1413Fb70",
                 "RISC0": "0x48940F7ab2C674Aa66C09eDa71614aD704E9d007",
-                "SGXGETH": "0x6B455442C8C4cAC2e09c40409E8bf7FfcdB1Fc50"
+                "SGXGETH": "0xFCA057AB211Dfaeb01FB8a36F4231Fb4021a6641"
             }
         },
         "genesis_time": 0,

--- a/lib/src/builder.rs
+++ b/lib/src/builder.rs
@@ -49,6 +49,14 @@ use reth_primitives::{
 };
 use tracing::{debug, error};
 
+fn assert_shasta_taiko_fork(taiko_fork: SpecId) {
+    assert_eq!(
+        taiko_fork,
+        SpecId::SHASTA,
+        "only SHASTA fork is supported, got {taiko_fork:?}"
+    );
+}
+
 pub fn calculate_block_header(input: &GuestInput) -> Header {
     let cycle_tracker = CycleTracker::start("initialize_database");
     let db = create_mem_db(&mut input.clone()).unwrap();
@@ -194,14 +202,19 @@ impl<DB: Database<Error = ProviderError> + DatabaseCommit + OptimisticDatabase>
         let total_difficulty = U256::ZERO;
         let reth_chain_spec = reth_chain_spec_for_name(&chain_spec.name);
 
+        let block_num = self.input.block.number;
         let block_ts = self.input.block.timestamp;
-        // Shasta-only: verify EVM fork activation
-        assert!(
-            reth_chain_spec
-                .fork(Hardfork::Shasta)
-                .active_at_timestamp(block_ts),
-            "evm fork SHASTA is not active, please update the chain spec"
-        );
+        let taiko_fork = self.input.chain_spec.spec_id(block_num, block_ts).unwrap();
+        if reth_chain_spec.is_taiko() {
+            assert_shasta_taiko_fork(taiko_fork);
+            // Shasta is activated by timestamp, not block number.
+            assert!(
+                reth_chain_spec
+                    .fork(Hardfork::Shasta)
+                    .active_at_timestamp(block_ts),
+                "evm fork SHASTA is not active, please update the chain spec"
+            );
+        }
 
         // Generate the transactions from the tx list
         let mut block = self.input.block.clone();
@@ -513,4 +526,28 @@ pub fn create_mem_db(input: &mut GuestInput) -> Result<MemDb> {
         accounts,
         block_hashes,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn shasta_fork_guard_accepts_shasta() {
+        assert_shasta_taiko_fork(SpecId::SHASTA);
+    }
+
+    #[test]
+    fn shasta_fork_guard_rejects_legacy_forks() {
+        for legacy_fork in [SpecId::HEKLA, SpecId::ONTAKE, SpecId::PACAYA] {
+            let panic = std::panic::catch_unwind(|| assert_shasta_taiko_fork(legacy_fork))
+                .expect_err("legacy fork should be rejected");
+            let message = panic
+                .downcast_ref::<String>()
+                .map(String::as_str)
+                .or_else(|| panic.downcast_ref::<&str>().copied())
+                .unwrap_or_default();
+            assert!(message.contains("only SHASTA fork is supported"));
+        }
+    }
 }

--- a/lib/src/builder.rs
+++ b/lib/src/builder.rs
@@ -5,7 +5,7 @@ use crate::primitives::keccak::keccak;
 use crate::primitives::mpt::StateAccount;
 use crate::utils::txs::{generate_transactions, generate_transactions_for_batch_blocks};
 use crate::{
-    consts::{ChainSpec, MAX_BLOCK_HASH_AGE},
+    consts::{ChainSpec, SpecId, MAX_BLOCK_HASH_AGE},
     guest_mem_forget,
     input::{GuestBatchInput, GuestInput},
     mem_db::{AccountState, DbAccount, MemDb},

--- a/lib/src/protocol_instance.rs
+++ b/lib/src/protocol_instance.rs
@@ -9,7 +9,7 @@ use reth_primitives::{Block, Header};
 #[cfg(not(feature = "std"))]
 use crate::no_std::*;
 use crate::{
-    consts::{ChainSpec, SupportedChainSpecs},
+    consts::SupportedChainSpecs,
     input::{
         shasta::{Checkpoint, Commitment, Proposal as ShastaProposal},
         BlobProofType, BlockProposedFork, GuestBatchInput, GuestInput,

--- a/lib/src/protocol_instance.rs
+++ b/lib/src/protocol_instance.rs
@@ -302,21 +302,40 @@ fn validate_chain_spec_against_known(chain_spec: &crate::consts::ChainSpec) -> R
 }
 
 fn bypass_shasta_anchor_linkage(batch_input: &GuestBatchInput) -> bool {
-    if !batch_input.taiko.l1_ancestor_headers.is_empty() {
+    let mut anchor_block_numbers = Vec::with_capacity(batch_input.inputs.len());
+    for input in &batch_input.inputs {
+        let Some(anchor_tx) = input.taiko.anchor_tx.as_ref() else {
+            error!("cannot bypass shasta anchor linkage: missing anchor tx");
+            return false;
+        };
+        let std::result::Result::Ok(anchor_data) = decode_anchor_shasta(anchor_tx.input()) else {
+            error!("cannot bypass shasta anchor linkage: failed to decode anchor tx");
+            return false;
+        };
+        anchor_block_numbers.push(anchor_data._checkpoint.blockNumber);
+    }
+
+    is_stalled_anchor_bypass_allowed(
+        batch_input.taiko.l1_ancestor_headers.is_empty(),
+        batch_input.taiko.prover_data.last_anchor_block_number,
+        &anchor_block_numbers,
+    )
+}
+
+fn is_stalled_anchor_bypass_allowed(
+    l1_ancestor_headers_empty: bool,
+    last_anchor_block_number: Option<u64>,
+    anchor_block_numbers: &[u64],
+) -> bool {
+    if !l1_ancestor_headers_empty || anchor_block_numbers.is_empty() {
         return false;
     }
-    let mut anchors = batch_input.inputs.iter().filter_map(|input| {
-        input
-            .taiko
-            .anchor_tx
-            .as_ref()
-            .and_then(|tx| decode_anchor_shasta(tx.input()).ok())
-            .map(|data| data._checkpoint.blockNumber)
-    });
-    let Some(first_anchor) = anchors.next() else {
+    let Some(last_anchor_block_number) = last_anchor_block_number else {
         return false;
     };
-    anchors.all(|h| h == first_anchor)
+    anchor_block_numbers
+        .iter()
+        .all(|anchor_block_number| *anchor_block_number == last_anchor_block_number)
 }
 
 impl ProtocolInstance {
@@ -695,6 +714,28 @@ mod tests {
 
     use super::*;
     use crate::input::shasta::Checkpoint;
+
+    #[test]
+    fn stalled_anchor_bypass_requires_last_anchor_match() {
+        assert!(is_stalled_anchor_bypass_allowed(
+            true,
+            Some(100),
+            &[100, 100]
+        ));
+        assert!(!is_stalled_anchor_bypass_allowed(
+            true,
+            Some(100),
+            &[101, 101]
+        ));
+        assert!(!is_stalled_anchor_bypass_allowed(
+            true,
+            Some(100),
+            &[100, 101]
+        ));
+        assert!(!is_stalled_anchor_bypass_allowed(false, Some(100), &[100]));
+        assert!(!is_stalled_anchor_bypass_allowed(true, None, &[100]));
+        assert!(!is_stalled_anchor_bypass_allowed(true, Some(100), &[]));
+    }
 
     #[test]
     fn test_shasta_aggregation_output() {

--- a/lib/src/protocol_instance.rs
+++ b/lib/src/protocol_instance.rs
@@ -1,6 +1,6 @@
 use std::collections::HashSet;
 
-use alloy_primitives::{Address, B256};
+use alloy_primitives::{Address, B256, U256};
 use alloy_sol_types::SolValue;
 use anyhow::{ensure, Ok, Result};
 use reth_evm_ethereum::taiko::decode_anchor_shasta;
@@ -22,6 +22,7 @@ use crate::{
     primitives::{
         eip4844::{self, commitment_to_version_hash},
         keccak::keccak,
+        mpt::{MptNode, StateAccount},
     },
     proof_type::ProofType,
     prover::{ProofCarryData, ShastaTransitionInput, TransitionInputData},
@@ -301,8 +302,96 @@ fn validate_chain_spec_against_known(chain_spec: &crate::consts::ChainSpec) -> R
     Ok(())
 }
 
+const SHASTA_ANCHOR_PREDEPLOY_SUFFIX: [u8; 3] = [0x01, 0x00, 0x01];
+// L2 SignalService proxy uses the same chain-id predeploy prefix as Anchor with suffix 0005.
+const SHASTA_SIGNAL_SERVICE_PREDEPLOY_SUFFIX: [u8; 3] = [0x00, 0x00, 0x05];
+// SignalService_Layout.sol: mapping(uint48 => CheckpointRecord) _checkpoints at slot 254.
+const SHASTA_SIGNAL_SERVICE_CHECKPOINTS_SLOT: u64 = 254;
+
+pub fn shasta_signal_service_address_from_l2_contract(
+    l2_contract: Option<Address>,
+) -> Option<Address> {
+    let mut bytes = [0u8; 20];
+    bytes.copy_from_slice(l2_contract?.as_slice());
+    if bytes[17..20] != SHASTA_ANCHOR_PREDEPLOY_SUFFIX {
+        return None;
+    }
+    bytes[17..20].copy_from_slice(&SHASTA_SIGNAL_SERVICE_PREDEPLOY_SUFFIX);
+    Some(Address::from_slice(&bytes))
+}
+
+pub fn shasta_checkpoint_storage_slots(block_number: u64) -> (U256, U256) {
+    let mut encoded = Vec::with_capacity(64);
+    encoded.extend_from_slice(&U256::from(block_number).to_be_bytes::<32>());
+    encoded
+        .extend_from_slice(&U256::from(SHASTA_SIGNAL_SERVICE_CHECKPOINTS_SLOT).to_be_bytes::<32>());
+    let block_hash_slot = U256::from_be_bytes::<32>(keccak(&encoded));
+    let state_root_slot = block_hash_slot + U256::from(1);
+    (block_hash_slot, state_root_slot)
+}
+
+fn read_storage_b256(storage_trie: &MptNode, slot: U256) -> Option<B256> {
+    let value = storage_trie
+        .get_rlp::<U256>(&keccak(slot.to_be_bytes::<32>()))
+        .ok()
+        .flatten()
+        .unwrap_or_default();
+    Some(B256::from_slice(&value.to_be_bytes::<32>()))
+}
+
+fn read_parent_shasta_checkpoint(input: &GuestInput, block_number: u64) -> Option<Checkpoint> {
+    let signal_service =
+        shasta_signal_service_address_from_l2_contract(input.chain_spec.l2_contract)?;
+    let (block_hash_slot, state_root_slot) = shasta_checkpoint_storage_slots(block_number);
+    let (storage_trie, _) = input.parent_storage.get(&signal_service)?;
+    if input.parent_state_trie.hash() != input.parent_header.state_root {
+        error!(
+            "cannot read parent shasta checkpoint: parent state trie root mismatch, expected: {:?}, got: {:?}",
+            input.parent_header.state_root,
+            input.parent_state_trie.hash()
+        );
+        return None;
+    }
+    let state_account = input
+        .parent_state_trie
+        .get_rlp::<StateAccount>(&keccak(signal_service))
+        .ok()
+        .flatten()?;
+    if storage_trie.hash() != state_account.storage_root {
+        error!(
+            "cannot read parent shasta checkpoint: signal service storage root mismatch, expected: {:?}, got: {:?}",
+            state_account.storage_root,
+            storage_trie.hash()
+        );
+        return None;
+    }
+    let block_hash = read_storage_b256(storage_trie, block_hash_slot)?;
+    let state_root = read_storage_b256(storage_trie, state_root_slot)?;
+    if block_hash == B256::ZERO || state_root == B256::ZERO {
+        return None;
+    }
+    Some(Checkpoint {
+        blockNumber: block_number,
+        blockHash: block_hash,
+        stateRoot: state_root,
+    })
+}
+
 fn bypass_shasta_anchor_linkage(batch_input: &GuestBatchInput) -> bool {
-    let mut anchor_block_numbers = Vec::with_capacity(batch_input.inputs.len());
+    if !batch_input.taiko.l1_ancestor_headers.is_empty() || batch_input.inputs.is_empty() {
+        return false;
+    }
+    let Some(last_anchor_block_number) = batch_input.taiko.prover_data.last_anchor_block_number
+    else {
+        return false;
+    };
+    let Some(parent_checkpoint) =
+        read_parent_shasta_checkpoint(&batch_input.inputs[0], last_anchor_block_number)
+    else {
+        error!("cannot bypass shasta anchor linkage: missing parent checkpoint");
+        return false;
+    };
+
     for input in &batch_input.inputs {
         let Some(anchor_tx) = input.taiko.anchor_tx.as_ref() else {
             error!("cannot bypass shasta anchor linkage: missing anchor tx");
@@ -312,16 +401,23 @@ fn bypass_shasta_anchor_linkage(batch_input: &GuestBatchInput) -> bool {
             error!("cannot bypass shasta anchor linkage: failed to decode anchor tx");
             return false;
         };
-        anchor_block_numbers.push(anchor_data._checkpoint.blockNumber);
+        let anchor_checkpoint = Checkpoint {
+            blockNumber: anchor_data._checkpoint.blockNumber,
+            blockHash: anchor_data._checkpoint.blockHash,
+            stateRoot: anchor_data._checkpoint.stateRoot,
+        };
+        if anchor_checkpoint != parent_checkpoint {
+            error!(
+                "cannot bypass shasta anchor linkage: anchor checkpoint mismatch, expected: {:?}, got: {:?}",
+                parent_checkpoint, anchor_checkpoint
+            );
+            return false;
+        }
     }
-
-    is_stalled_anchor_bypass_allowed(
-        batch_input.taiko.l1_ancestor_headers.is_empty(),
-        batch_input.taiko.prover_data.last_anchor_block_number,
-        &anchor_block_numbers,
-    )
+    true
 }
 
+#[cfg(test)]
 fn is_stalled_anchor_bypass_allowed(
     l1_ancestor_headers_empty: bool,
     last_anchor_block_number: Option<u64>,
@@ -710,10 +806,18 @@ fn bind_aggregate_hash_with_zk_image_id(sub_image_id: B256, sub_input_hash: B256
 }
 #[cfg(test)]
 mod tests {
-    use alloy_primitives::{address, b256};
+    use std::collections::HashMap;
+
+    use alloy_primitives::{address, b256, Bytes, U256};
+    use alloy_sol_types::SolCall;
+    use reth_evm_ethereum::taiko::anchorV4Call;
+    use reth_primitives::{Header, Signature, TransactionSigned, TxKind, TxLegacy};
 
     use super::*;
-    use crate::input::shasta::Checkpoint;
+    use crate::{
+        input::{shasta::Checkpoint, TaikoGuestBatchInput, TaikoProverData},
+        primitives::mpt::MptNode,
+    };
 
     #[test]
     fn stalled_anchor_bypass_requires_last_anchor_match() {
@@ -735,6 +839,136 @@ mod tests {
         assert!(!is_stalled_anchor_bypass_allowed(false, Some(100), &[100]));
         assert!(!is_stalled_anchor_bypass_allowed(true, None, &[100]));
         assert!(!is_stalled_anchor_bypass_allowed(true, Some(100), &[]));
+    }
+
+    fn test_checkpoint_storage_slots(block_number: u64) -> (U256, U256) {
+        shasta_checkpoint_storage_slots(block_number)
+    }
+
+    fn test_anchor_tx(checkpoint: Checkpoint) -> TransactionSigned {
+        let input = anchorV4Call {
+            _checkpoint: reth_evm_ethereum::taiko::Checkpoint {
+                blockNumber: checkpoint.blockNumber,
+                blockHash: checkpoint.blockHash,
+                stateRoot: checkpoint.stateRoot,
+            },
+        }
+        .abi_encode();
+        let tx = TxLegacy {
+            to: TxKind::Call(address!("1670010000000000000000000000000000010001")),
+            input: Bytes::from(input),
+            ..Default::default()
+        };
+        TransactionSigned::from_transaction_and_signature(tx.into(), Signature::default())
+    }
+
+    fn test_input_with_parent_checkpoint(
+        anchor_tx_checkpoint: Checkpoint,
+        parent_checkpoint: Checkpoint,
+    ) -> GuestInput {
+        let signal_service = address!("1670010000000000000000000000000000000005");
+        let (block_hash_slot, state_root_slot) =
+            test_checkpoint_storage_slots(parent_checkpoint.blockNumber);
+        let mut storage_trie = MptNode::default();
+        storage_trie
+            .insert_rlp(
+                &keccak(block_hash_slot.to_be_bytes::<32>()),
+                U256::from_be_bytes::<32>(*parent_checkpoint.blockHash),
+            )
+            .unwrap();
+        storage_trie
+            .insert_rlp(
+                &keccak(state_root_slot.to_be_bytes::<32>()),
+                U256::from_be_bytes::<32>(*parent_checkpoint.stateRoot),
+            )
+            .unwrap();
+        let mut parent_state_trie = MptNode::default();
+        parent_state_trie
+            .insert_rlp(
+                &keccak(signal_service),
+                StateAccount {
+                    storage_root: storage_trie.hash(),
+                    ..Default::default()
+                },
+            )
+            .unwrap();
+
+        let mut parent_storage = HashMap::new();
+        parent_storage.insert(
+            signal_service,
+            (storage_trie, vec![block_hash_slot, state_root_slot]),
+        );
+
+        GuestInput {
+            chain_spec: crate::consts::ChainSpec {
+                l2_contract: Some(address!("1670010000000000000000000000000000010001")),
+                ..Default::default()
+            },
+            parent_header: Header {
+                state_root: parent_state_trie.hash(),
+                ..Default::default()
+            },
+            parent_state_trie,
+            parent_storage,
+            taiko: crate::input::TaikoGuestInput {
+                anchor_tx: Some(test_anchor_tx(anchor_tx_checkpoint)),
+                ..Default::default()
+            },
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn stalled_anchor_bypass_rejects_checkpoint_value_mismatch() {
+        let parent_checkpoint = Checkpoint {
+            blockNumber: 100,
+            blockHash: b256!("1111111111111111111111111111111111111111111111111111111111111111"),
+            stateRoot: b256!("2222222222222222222222222222222222222222222222222222222222222222"),
+        };
+        let forged_checkpoint = Checkpoint {
+            blockNumber: parent_checkpoint.blockNumber,
+            blockHash: b256!("3333333333333333333333333333333333333333333333333333333333333333"),
+            stateRoot: parent_checkpoint.stateRoot,
+        };
+        let batch_input = GuestBatchInput {
+            inputs: vec![test_input_with_parent_checkpoint(
+                forged_checkpoint,
+                parent_checkpoint,
+            )],
+            taiko: TaikoGuestBatchInput {
+                prover_data: TaikoProverData {
+                    last_anchor_block_number: Some(100),
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+        };
+
+        assert!(!bypass_shasta_anchor_linkage(&batch_input));
+    }
+
+    #[test]
+    fn stalled_anchor_bypass_accepts_parent_checkpoint_match() {
+        let parent_checkpoint = Checkpoint {
+            blockNumber: 100,
+            blockHash: b256!("1111111111111111111111111111111111111111111111111111111111111111"),
+            stateRoot: b256!("2222222222222222222222222222222222222222222222222222222222222222"),
+        };
+        let batch_input = GuestBatchInput {
+            inputs: vec![test_input_with_parent_checkpoint(
+                parent_checkpoint.clone(),
+                parent_checkpoint,
+            )],
+            taiko: TaikoGuestBatchInput {
+                prover_data: TaikoProverData {
+                    last_anchor_block_number: Some(100),
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+        };
+
+        assert!(bypass_shasta_anchor_linkage(&batch_input));
     }
 
     #[test]

--- a/lib/src/protocol_instance.rs
+++ b/lib/src/protocol_instance.rs
@@ -276,7 +276,12 @@ fn validate_known_chain_spec(chain_spec: &crate::consts::ChainSpec) -> Result<()
     else {
         return Ok(());
     };
-    ensure!(chain_spec.name == verified.name, "unexpected name");
+    ensure!(
+        chain_spec.name == verified.name,
+        "unexpected name: {:?}, expected: {:?}",
+        chain_spec.name,
+        verified.name
+    );
     ensure!(
         chain_spec.max_spec_id == verified.max_spec_id,
         "unexpected max_spec_id"

--- a/lib/src/protocol_instance.rs
+++ b/lib/src/protocol_instance.rs
@@ -9,7 +9,7 @@ use reth_primitives::{Block, Header};
 #[cfg(not(feature = "std"))]
 use crate::no_std::*;
 use crate::{
-    consts::SupportedChainSpecs,
+    consts::{ChainSpec, SupportedChainSpecs},
     input::{
         shasta::{Checkpoint, Commitment, Proposal as ShastaProposal},
         BlobProofType, BlockProposedFork, GuestBatchInput, GuestInput,
@@ -29,7 +29,6 @@ use crate::{
     CycleTracker,
 };
 use tracing::{debug, error, info};
-
 #[derive(Debug, Clone)]
 pub enum BlockMetaDataFork {
     None,
@@ -271,12 +270,13 @@ fn verify_shasha_anchor_linkage(
 
 /// Validates input chain spec against known specs when chain_id is recognized.
 /// For unknown chain ids, skips check to allow tests with custom data.
-fn validate_chain_spec_against_known(chain_spec: &crate::consts::ChainSpec) -> Result<()> {
+fn validate_known_chain_spec(chain_spec: &crate::consts::ChainSpec) -> Result<()> {
     let Some(verified) =
         SupportedChainSpecs::default().get_chain_spec_with_chain_id(chain_spec.chain_id)
     else {
         return Ok(());
     };
+    ensure!(chain_spec.name == verified.name, "unexpected name");
     ensure!(
         chain_spec.max_spec_id == verified.max_spec_id,
         "unexpected max_spec_id"
@@ -298,6 +298,10 @@ fn validate_chain_spec_against_known(chain_spec: &crate::consts::ChainSpec) -> R
     ensure!(
         chain_spec.l2_contract == verified.l2_contract,
         "unexpected l2_contract"
+    );
+    ensure!(
+        chain_spec.is_taiko == verified.is_taiko,
+        "unexpected is_taiko"
     );
     Ok(())
 }
@@ -450,7 +454,7 @@ impl ProtocolInstance {
         verify_batch_mode_blob_usage(batch_input, proof_type)?;
 
         for input in &batch_input.inputs {
-            validate_chain_spec_against_known(&input.chain_spec)?;
+            validate_known_chain_spec(&input.chain_spec)?;
         }
 
         // todo: move chain_spec into the batch input
@@ -969,6 +973,25 @@ mod tests {
         };
 
         assert!(bypass_shasta_anchor_linkage(&batch_input));
+    }
+
+    #[test]
+    fn known_chain_spec_rejects_name_mismatch() {
+        let mut chain_spec = crate::consts::SupportedChainSpecs::default()
+            .get_chain_spec("taiko_mainnet")
+            .unwrap();
+        chain_spec.name = "taiko_dev".to_string();
+        let batch_input = GuestBatchInput {
+            inputs: vec![GuestInput {
+                chain_spec,
+                ..Default::default()
+            }],
+            ..Default::default()
+        };
+
+        let err = ProtocolInstance::new_batch(&batch_input, Vec::new(), ProofType::Sgx)
+            .expect_err("chain spec name mismatch should be rejected");
+        assert!(err.to_string().contains("unexpected name"));
     }
 
     #[test]

--- a/lib/src/utils/shasta.rs
+++ b/lib/src/utils/shasta.rs
@@ -161,7 +161,7 @@ pub fn generate_transactions_for_shasta_blocks(
                     assert!(
                         validate_input_block_param(
                             block_manifest,
-                            &guest_batch_input.inputs[idx + offset].block
+                            &guest_batch_input.inputs[idx + offset]
                         ),
                         "input block manifest is invalid"
                     );
@@ -212,7 +212,7 @@ pub fn generate_transactions_for_shasta_blocks(
             assert!(
                 validate_input_block_param(
                     force_inc_block_manifest,
-                    &guest_batch_input.inputs[idx].block
+                    &guest_batch_input.inputs[idx]
                 ),
                 "force inclusion source is invalid"
             );

--- a/lib/src/utils/shasta_rules.rs
+++ b/lib/src/utils/shasta_rules.rs
@@ -1,7 +1,7 @@
 use core::cmp::{max, min};
-use reth_evm_ethereum::taiko::ANCHOR_V4_GAS_LIMIT;
+use reth_evm_ethereum::taiko::{decode_anchor_shasta, ANCHOR_V4_GAS_LIMIT};
 use reth_primitives::revm_primitives::SpecId;
-use reth_primitives::{Block, Header};
+use reth_primitives::Header;
 use std::cmp::max as std_max;
 use tracing::{info, warn};
 
@@ -244,8 +244,9 @@ pub(crate) fn validate_force_inc_proposal_manifest(manifest: &DerivationSourceMa
 
 pub(crate) fn validate_input_block_param(
     manifest_block: &ProtocolBlockManifest,
-    input_block: &Block,
+    input: &GuestInput,
 ) -> bool {
+    let input_block = &input.block;
     if manifest_block.timestamp != input_block.header.timestamp {
         warn!(
             "manifest_block.timestamp != input_block.header.timestamp, manifest_block.timestamp: {}, input_block.header.timestamp: {}",
@@ -264,6 +265,32 @@ pub(crate) fn validate_input_block_param(
         warn!(
             "manifest_block.gas_limit != input_block.header.gas_limit, manifest_block.gas_limit: {}, input_block.header.gas_limit: {}",
             manifest_block.gas_limit, input_block.header.gas_limit
+        );
+        return false;
+    }
+    let Some(anchor_tx) = &input.taiko.anchor_tx else {
+        warn!("input block missing shasta anchor tx");
+        return false;
+    };
+    if !validate_shasta_anchor_tx_for_manifest_block(manifest_block, anchor_tx.input()) {
+        return false;
+    }
+    true
+}
+
+fn validate_shasta_anchor_tx_for_manifest_block(
+    manifest_block: &ProtocolBlockManifest,
+    anchor_tx_input: &[u8],
+) -> bool {
+    let Ok(anchor_data) = decode_anchor_shasta(anchor_tx_input) else {
+        warn!("failed to decode shasta anchor tx calldata");
+        return false;
+    };
+    if anchor_data._checkpoint.blockNumber != manifest_block.anchor_block_number {
+        warn!(
+            "manifest_block.anchor_block_number != anchor_tx checkpoint blockNumber, manifest_block.anchor_block_number: {}, anchor_tx checkpoint blockNumber: {}",
+            manifest_block.anchor_block_number,
+            anchor_data._checkpoint.blockNumber
         );
         return false;
     }
@@ -656,12 +683,25 @@ mod tests {
         BlockProposedFork, GuestBatchInput, GuestInput, TaikoGuestBatchInput,
     };
     use crate::manifest::{DerivationSourceManifest, ProtocolBlockManifest};
-    use alloy_primitives::B256;
+    use alloy_primitives::{Address, B256};
+    use alloy_sol_types::SolCall;
+    use reth_evm_ethereum::taiko::{anchorV4Call, Checkpoint};
     use reth_primitives::revm_primitives::SpecId;
     use reth_primitives::Header;
     use std::collections::BTreeMap;
 
     use super::calc_next_shasta_base_fee;
+
+    fn shasta_anchor_input(anchor_block_number: u64) -> Vec<u8> {
+        anchorV4Call {
+            _checkpoint: Checkpoint {
+                blockNumber: anchor_block_number,
+                blockHash: B256::ZERO,
+                stateRoot: B256::ZERO,
+            },
+        }
+        .abi_encode()
+    }
 
     fn base_fee_guest_input(parent_header: Header, block_base_fee: u64) -> GuestInput {
         let mut input = GuestInput {
@@ -670,6 +710,30 @@ mod tests {
         };
         input.block.header.base_fee_per_gas = Some(block_base_fee);
         input
+    }
+
+    #[test]
+    fn validate_shasta_anchor_tx_for_manifest_block_rejects_anchor_mismatch() {
+        let manifest_block = ProtocolBlockManifest {
+            timestamp: 100,
+            coinbase: Address::ZERO,
+            anchor_block_number: 100,
+            gas_limit: 20_000_000,
+            transactions: Vec::new(),
+        };
+
+        assert!(!super::validate_shasta_anchor_tx_for_manifest_block(
+            &manifest_block,
+            &shasta_anchor_input(101)
+        ));
+        assert!(super::validate_shasta_anchor_tx_for_manifest_block(
+            &manifest_block,
+            &shasta_anchor_input(100)
+        ));
+        assert!(!super::validate_shasta_anchor_tx_for_manifest_block(
+            &manifest_block,
+            b"not-anchor-calldata"
+        ));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Port the remaining Shasta hotfix soundness changes after #697 to main: #698, #699, and #700.
- Harden Shasta guest execution by enforcing Shasta fork selection, manifest anchor binding, and stalled-anchor bypass constraints.
- Bind stalled-anchor checkpoint calldata to the parent L2 SignalService checkpoint included in parent state witnesses.
- Bind known chain specs by name/is_taiko and bump gaiko to taikoxyz/gaiko#33 for matching witness-side validation.

## Test Plan
- cargo fmt -p raiko-lib -- --check
- cargo test -p raiko-lib --lib
- cargo check -p raiko-core
- go test ./internal/witness -count=1
- git diff --check origin/main...HEAD