### PR TITLE
feat(host): add v4 proposal proof API adapter

### DIFF
--- a/host/src/server/api/mod.rs
+++ b/host/src/server/api/mod.rs
@@ -20,6 +20,7 @@ pub mod public;
 pub mod v1;
 pub mod v2;
 pub mod v3;
+pub mod v4;
 
 pub const MAX_BODY_SIZE: usize = 1 << 20;
 
@@ -46,12 +47,14 @@ pub fn create_router(
     let v1_api = v1::create_router(concurrency_limit);
     let v2_api = v2::create_router();
     let v3_api = v3::create_router();
+    let v4_api = v4::create_router();
     let admin_api = admin::create_router();
 
     let mut router = Router::new()
         .nest("/v1", v1_api)
         .nest("/v2", v2_api)
         .nest("/v3", v3_api.clone())
+        .nest("/v4", v4_api)
         .merge(v3_api)
         .nest("/admin", admin_api)
         .layer(middleware)

--- a/host/src/server/api/v3/mod.rs
+++ b/host/src/server/api/v3/mod.rs
@@ -14,7 +14,7 @@ pub use crate::server::api::v2::ProofResponse;
 pub use crate::server::api::v2::PruneStatus;
 pub use crate::server::api::v2::Status;
 
-mod proof;
+pub(crate) mod proof;
 
 #[derive(OpenApi)]
 #[openapi(

--- a/host/src/server/api/v3/proof/mod.rs
+++ b/host/src/server/api/v3/proof/mod.rs
@@ -23,7 +23,7 @@ mod aggregate;
 mod batch;
 mod batch_handler;
 mod cancel;
-mod shasta_handler;
+pub(crate) mod shasta_handler;
 
 #[utoipa::path(post, path = "/proof",
     tag = "Proving",

--- a/host/src/server/api/v3/proof/shasta_handler.rs
+++ b/host/src/server/api/v3/proof/shasta_handler.rs
@@ -47,7 +47,15 @@ use super::batch::process_shasta_batch;
 async fn shasta_batch_handler(
     State(actor): State<Actor>,
     Extension(authenticated_key): Extension<AuthenticatedApiKey>,
-    Json(mut shasta_request_opt): Json<Value>,
+    Json(shasta_request_opt): Json<Value>,
+) -> HostResult<Status> {
+    handle_shasta_batch_request(actor, authenticated_key, shasta_request_opt).await
+}
+
+pub(crate) async fn handle_shasta_batch_request(
+    actor: Actor,
+    authenticated_key: AuthenticatedApiKey,
+    mut shasta_request_opt: Value,
 ) -> HostResult<Status> {
     tracing::info!(
         "Incoming Shasta batch request: {} from {}",

--- a/host/src/server/api/v4.rs
+++ b/host/src/server/api/v4.rs
@@ -1,0 +1,290 @@
+use crate::server::{
+    api::v3::{
+        proof::shasta_handler::handle_shasta_batch_request, ProofResponse, Status as V3Status,
+    },
+    auth::AuthenticatedApiKey,
+};
+use axum::{extract::State, routing::post, Extension, Json, Router};
+use raiko_reqactor::Actor;
+use raiko_tasks::TaskStatus;
+use serde::Deserialize;
+use serde_json::{json, Value};
+
+const MAX_V4_L2_BLOCK_RANGE_LEN: u64 = 100_000;
+const MAX_V4_TOTAL_L2_BLOCKS_PER_REQUEST: u64 = MAX_V4_L2_BLOCK_RANGE_LEN;
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct V4ProofRequest {
+    proof_type: String,
+    proposals: Vec<V4ProposalRequest>,
+    #[serde(default)]
+    aggregate: bool,
+    #[serde(default)]
+    prover: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct V4ProposalRequest {
+    proposal_id: u64,
+    #[serde(default)]
+    checkpoint: Option<Value>,
+    l1_inclusion_block_number: u64,
+    l2_block_number_start: u64,
+    l2_block_number_end: u64,
+    last_anchor_block_number: u64,
+}
+
+struct V4Conversion {
+    shasta_value: Value,
+    proposal_id_start: u64,
+    proposal_id_end: u64,
+}
+
+async fn proposal_proof_handler(
+    State(actor): State<Actor>,
+    Extension(authenticated_key): Extension<AuthenticatedApiKey>,
+    Json(request): Json<Value>,
+) -> Json<Value> {
+    let conversion = match v4_to_shasta_conversion(request) {
+        Ok(conversion) => conversion,
+        Err(message) => return Json(v4_error("invalid_request", message)),
+    };
+
+    let response = match handle_shasta_batch_request(
+        actor,
+        authenticated_key,
+        conversion.shasta_value.clone(),
+    )
+    .await
+    {
+        Ok(status) => v3_status_to_v4_value(&conversion, status),
+        Err(error) => v4_error("proof_request_failed", error.to_string()),
+    };
+
+    Json(response)
+}
+
+#[cfg(test)]
+fn v4_to_shasta_value(request: Value) -> Result<Value, String> {
+    v4_to_shasta_conversion(request).map(|conversion| conversion.shasta_value)
+}
+
+fn v4_to_shasta_conversion(request: Value) -> Result<V4Conversion, String> {
+    let request: V4ProofRequest =
+        serde_json::from_value(request).map_err(|err| format!("invalid v4 request: {err}"))?;
+    let first_proposal = request
+        .proposals
+        .first()
+        .ok_or_else(|| "proposals must not be empty".to_string())?;
+    if !request.aggregate && request.proposals.len() != 1 {
+        return Err("aggregate=false accepts exactly one proposal".to_string());
+    }
+
+    let proposal_id_start = first_proposal.proposal_id;
+    let proposal_id_end = request
+        .proposals
+        .last()
+        .map(|proposal| proposal.proposal_id)
+        .unwrap_or(proposal_id_start);
+    let proof_type = request.proof_type;
+    let mut total_l2_blocks = 0_u64;
+    let mut proposals = Vec::with_capacity(request.proposals.len());
+    for proposal in request.proposals {
+        let (proposal, range_len) = v4_proposal_to_shasta_value(proposal)?;
+        total_l2_blocks = total_l2_blocks
+            .checked_add(range_len)
+            .ok_or_else(|| "total proposals[].l2 block range length overflows u64".to_string())?;
+        if total_l2_blocks > MAX_V4_TOTAL_L2_BLOCKS_PER_REQUEST {
+            return Err(format!(
+                "total proposals[].l2 block range length {total_l2_blocks} exceeds maximum \
+                 {MAX_V4_TOTAL_L2_BLOCKS_PER_REQUEST}"
+            ));
+        }
+        proposals.push(proposal);
+    }
+
+    let mut shasta_value = json!({
+        "proof_type": proof_type,
+        "aggregate": request.aggregate,
+        "proposals": proposals,
+    });
+    if let Some(prover) = request.prover {
+        shasta_value["prover"] = json!(prover);
+    }
+
+    Ok(V4Conversion {
+        shasta_value,
+        proposal_id_start,
+        proposal_id_end,
+    })
+}
+
+fn v4_proposal_to_shasta_value(proposal: V4ProposalRequest) -> Result<(Value, u64), String> {
+    let range_len = proposal
+        .l2_block_number_end
+        .checked_sub(proposal.l2_block_number_start)
+        .and_then(|len| len.checked_add(1))
+        .ok_or_else(|| {
+            "proposals[].l2_block_number_end must be greater than or equal to \
+             proposals[].l2_block_number_start"
+                .to_string()
+        })?;
+    if range_len > MAX_V4_L2_BLOCK_RANGE_LEN {
+        return Err(format!(
+            "proposals[].l2_block_number_start..=proposals[].l2_block_number_end range length \
+             {range_len} exceeds maximum {MAX_V4_L2_BLOCK_RANGE_LEN}"
+        ));
+    }
+
+    let l2_block_numbers =
+        (proposal.l2_block_number_start..=proposal.l2_block_number_end).collect::<Vec<_>>();
+    let mut shasta_proposal = json!({
+        "proposal_id": proposal.proposal_id,
+        "l1_inclusion_block_number": proposal.l1_inclusion_block_number,
+        "l2_block_numbers": l2_block_numbers,
+        "last_anchor_block_number": proposal.last_anchor_block_number,
+    });
+    if let Some(checkpoint) = proposal.checkpoint {
+        shasta_proposal["checkpoint"] = checkpoint;
+    }
+
+    Ok((shasta_proposal, range_len))
+}
+
+fn v3_status_to_v4_value(conversion: &V4Conversion, status: V3Status) -> Value {
+    match status {
+        V3Status::Ok {
+            proof_type, data, ..
+        } => {
+            let task_id = format!(
+                "legacy-shasta-{}-{}-{}",
+                conversion.proposal_id_start, conversion.proposal_id_end, proof_type
+            );
+            let (status, proof, error) = match data {
+                ProofResponse::Status { status } => {
+                    let error = task_status_error(&status);
+                    (task_status_to_v4(&status), None, error)
+                }
+                ProofResponse::Proof { proof } => ("completed".to_string(), proof.proof, None),
+            };
+
+            let mut data = json!({
+                "task_id": task_id,
+                "status": status,
+                "proof": proof,
+            });
+            if let Some(error) = error {
+                data["error"] = json!(error);
+            }
+
+            json!({
+                "status": "ok",
+                "proof_type": proof_type.to_string(),
+                "proposal_id_start": conversion.proposal_id_start,
+                "proposal_id_end": conversion.proposal_id_end,
+                "data": data,
+            })
+        }
+        V3Status::Error { error, message } => v4_error(&error, message),
+    }
+}
+
+fn task_status_to_v4(status: &TaskStatus) -> String {
+    match status {
+        TaskStatus::Success => "completed".to_string(),
+        TaskStatus::Registered => "registered".to_string(),
+        TaskStatus::WorkInProgress => "work_in_progress".to_string(),
+        TaskStatus::Cancelled
+        | TaskStatus::Cancelled_NeverStarted
+        | TaskStatus::Cancelled_Aborted
+        | TaskStatus::CancellationInProgress => "cancelled".to_string(),
+        TaskStatus::ZKAnyNotDrawn => "zk_any_not_drawn".to_string(),
+        _ => "failed".to_string(),
+    }
+}
+
+fn task_status_error(status: &TaskStatus) -> Option<String> {
+    match status {
+        TaskStatus::Success
+        | TaskStatus::Registered
+        | TaskStatus::WorkInProgress
+        | TaskStatus::ZKAnyNotDrawn => None,
+        TaskStatus::NetworkFailure(error)
+        | TaskStatus::IoFailure(error)
+        | TaskStatus::AnyhowError(error)
+        | TaskStatus::GuestProverFailure(error)
+        | TaskStatus::TaskDbCorruption(error) => Some(error.clone()),
+        other => Some(format!("{other:?}")),
+    }
+}
+
+fn v4_error(error: &str, message: String) -> Value {
+    json!({
+        "status": "error",
+        "error": error,
+        "message": message,
+    })
+}
+
+pub fn create_router() -> Router<Actor> {
+    Router::new().route("/proof/proposal", post(proposal_proof_handler))
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    #[test]
+    fn converts_v4_proposal_ranges_to_shasta_l2_block_numbers() {
+        let input = json!({
+            "proof_type": "sgx",
+            "aggregate": false,
+            "proposals": [{
+                "proposal_id": 42,
+                "l1_inclusion_block_number": 100,
+                "l2_block_number_start": 200,
+                "l2_block_number_end": 202,
+                "last_anchor_block_number": 199
+            }],
+            "prover": "0x0000000000000000000000000000000000000000"
+        });
+
+        let converted = super::v4_to_shasta_value(input).expect("convert v4 request");
+        assert_eq!(converted["proof_type"], "sgx");
+        assert_eq!(converted["aggregate"], false);
+        assert_eq!(
+            converted["prover"],
+            "0x0000000000000000000000000000000000000000"
+        );
+        assert_eq!(converted["proposals"][0]["proposal_id"], 42);
+        assert_eq!(
+            converted["proposals"][0]["l2_block_numbers"],
+            json!([200, 201, 202])
+        );
+        assert!(converted["proposals"][0]
+            .get("l2_block_number_start")
+            .is_none());
+        assert!(converted["proposals"][0]
+            .get("l2_block_number_end")
+            .is_none());
+    }
+
+    #[test]
+    fn rejects_v4_proposal_range_with_end_before_start() {
+        let input = json!({
+            "proof_type": "sgx",
+            "proposals": [{
+                "proposal_id": 42,
+                "l1_inclusion_block_number": 100,
+                "l2_block_number_start": 202,
+                "l2_block_number_end": 200,
+                "last_anchor_block_number": 199
+            }]
+        });
+
+        let err = super::v4_to_shasta_value(input).expect_err("reject invalid range");
+        assert!(err.contains("l2_block_number_end must be greater than or equal to"));
+    }
+}

--- a/script/stress_shasta_proposal.py
+++ b/script/stress_shasta_proposal.py
@@ -11,12 +11,17 @@ from dataclasses import dataclass
 from random import random
 import web3
 from web3 import Web3
-from web3.middleware import ExtraDataToPOAMiddleware
+try:
+    from web3.middleware import ExtraDataToPOAMiddleware
+except ImportError:
+    from web3.middleware import geth_poa_middleware as ExtraDataToPOAMiddleware
 import sys
 import os
 from shasta_event_decoder import ShastaEventDecoder
 
 MAX_BLOCKS_PER_PROPOSAL = 192
+DEFAULT_PROVER = "0x70997970C51812dc3A010C7d01b50e0d17dc79C8"
+SUPPORTED_SHASTA_API_VERSIONS = {"v3", "v4"}
 
 
 @dataclass
@@ -42,6 +47,120 @@ class ProposalGroup:
     l2_block_numbers: list[int]
 
 
+def normalize_shasta_api_version(api_version: str) -> str:
+    normalized = api_version.lower()
+    if normalized not in SUPPORTED_SHASTA_API_VERSIONS:
+        raise ValueError(
+            f"Unsupported Shasta proof API version {api_version}; "
+            f"expected one of {sorted(SUPPORTED_SHASTA_API_VERSIONS)}"
+        )
+    return normalized
+
+
+def shasta_proof_endpoint(raiko_rpc: str, api_version: str) -> str:
+    base = raiko_rpc.rstrip("/")
+    normalized = normalize_shasta_api_version(api_version)
+    if normalized == "v4":
+        return f"{base}/v4/proof/proposal"
+    return f"{base}/v3/proof/batch/shasta"
+
+
+def get_contract_event_logs(event, from_block, to_block):
+    try:
+        return event.get_logs(from_block=from_block, to_block=to_block)
+    except TypeError as err:
+        if "from_block" not in str(err) and "to_block" not in str(err):
+            raise
+        return event.get_logs(fromBlock=from_block, toBlock=to_block)
+
+
+def _proposal_l2_range(proposal: Dict[str, Any]) -> tuple[int, int]:
+    l2_block_numbers = proposal.get("l2_block_numbers")
+    if not l2_block_numbers:
+        raise ValueError("proposal l2_block_numbers must not be empty")
+
+    start = int(l2_block_numbers[0])
+    end = int(l2_block_numbers[-1])
+    if l2_block_numbers != list(range(start, end + 1)):
+        raise ValueError("v4 Shasta proof API requires contiguous l2_block_numbers")
+    return start, end
+
+
+def proposal_for_shasta_api(proposal: Dict[str, Any], api_version: str) -> Dict[str, Any]:
+    normalized = normalize_shasta_api_version(api_version)
+    if normalized == "v3":
+        return dict(proposal)
+
+    start, end = _proposal_l2_range(proposal)
+    converted = dict(proposal)
+    converted.pop("l2_block_numbers", None)
+    converted["l2_block_number_start"] = start
+    converted["l2_block_number_end"] = end
+    return converted
+
+
+def generate_shasta_post_data(
+    proposals: list[Dict[str, Any]],
+    proof_type: str,
+    aggregate: bool = False,
+    api_version: str = "v3",
+) -> Dict[str, Any]:
+    normalized = normalize_shasta_api_version(api_version)
+    converted_proposals = [
+        proposal_for_shasta_api(proposal, normalized) for proposal in proposals
+    ]
+
+    if normalized == "v4":
+        return {
+            "proposals": converted_proposals,
+            "prover": DEFAULT_PROVER,
+            "proof_type": proof_type,
+            "aggregate": aggregate,
+        }
+
+    return {
+        "proposals": converted_proposals,
+        "prover": DEFAULT_PROVER,
+        "graffiti": "8008500000000000000000000000000000000000000000000000000000000000",
+        "proof_type": proof_type,
+        "blob_proof_type": "proof_of_equivalence",
+        "aggregate": aggregate,
+        "native": {},
+        "sgx": {
+            "instance_id": 1234,
+            "setup": False,
+            "bootstrap": False,
+            "prove": True,
+        },
+        "risc0": {
+            "bonsai": False,
+            "snark": True,
+            "profile": True,
+            "execution_po2": 20,
+        },
+        "sp1": {"recursion": "plonk", "prover": "network", "verify": True},
+    }
+
+
+def extract_proof_from_response_data(data: Optional[Dict[str, Any]]) -> Optional[str]:
+    if not data:
+        return None
+
+    proof = data.get("proof")
+    if isinstance(proof, str):
+        return proof
+    if isinstance(proof, dict):
+        inner_proof = proof.get("proof")
+        return inner_proof if isinstance(inner_proof, str) else None
+    return None
+
+
+def is_completed_response_data(data: Optional[Dict[str, Any]]) -> bool:
+    if not data:
+        return False
+    return data.get("status") == "completed" or extract_proof_from_response_data(data) is not None
+
+
 class BatchMonitor:
     def __init__(
         self,
@@ -61,6 +180,7 @@ class BatchMonitor:
         time_speed: float = 1.0,
         anchor_abi_file: Optional[str] = None,
         aggregate: int = 0,
+        proof_api_version: str = "v3",
     ):
         self.l1_rpc = l1_rpc
         self.l2_rpc = l2_rpc
@@ -82,6 +202,7 @@ class BatchMonitor:
         self.time_speed = time_speed
         self.anchor_abi_file = anchor_abi_file
         self.aggregate = aggregate
+        self.proof_api_version = normalize_shasta_api_version(proof_api_version)
         # Initialize Shasta event decoder
         self.shasta_decoder = ShastaEventDecoder()
         # Cache for proposal block numbers: proposal_id -> l1_block_number
@@ -611,8 +732,8 @@ class BatchMonitor:
         
         try:
             # Get events in the range
-            logs = self.evt_contract.events.Proposed.get_logs(
-                from_block=search_start, to_block=search_end
+            logs = get_contract_event_logs(
+                self.evt_contract.events.Proposed, search_start, search_end
             )
             
             for log in logs:
@@ -675,8 +796,8 @@ class BatchMonitor:
         )
         
         try:
-            logs = self.evt_contract.events.Proposed.get_logs(
-                from_block=search_start, to_block=search_end
+            logs = get_contract_event_logs(
+                self.evt_contract.events.Proposed, search_start, search_end
             )
             
             # Build a map of proposal_id -> block_number from all logs
@@ -734,8 +855,8 @@ class BatchMonitor:
 
     def get_batch_events_in_block(self, block_number) -> list[int]:
         try:
-            logs = self.evt_contract.events.Proposed.get_logs(
-                from_block=block_number, to_block=block_number
+            logs = get_contract_event_logs(
+                self.evt_contract.events.Proposed, block_number, block_number
             )
 
             batch_ids = []
@@ -865,8 +986,8 @@ class BatchMonitor:
 
     async def get_latest_block_batchs(self) -> Optional[tuple[int, list[int]]]:
         """get latest block number"""
-        logs = self.evt_contract.events.Proposed().get_logs(
-            from_block="latest", to_block="latest"
+        logs = get_contract_event_logs(
+            self.evt_contract.events.Proposed(), "latest", "latest"
         )
         if len(logs) == 0:
             return None
@@ -892,28 +1013,12 @@ class BatchMonitor:
         aggregate: bool = False
     ) -> Dict[str, Any]:
         """generate post data"""
-        return {
-            "proposals": proposals,
-            "prover": "0x70997970C51812dc3A010C7d01b50e0d17dc79C8",
-            "graffiti": "8008500000000000000000000000000000000000000000000000000000000000",
-            "proof_type": self.prove_type,
-            "blob_proof_type": "proof_of_equivalence",
-            "aggregate": aggregate,
-            "native": {},
-            "sgx": {
-                "instance_id": 1234,
-                "setup": False,
-                "bootstrap": False,
-                "prove": True,
-            },
-            "risc0": {
-                "bonsai": False,
-                "snark": True,
-                "profile": True,
-                "execution_po2": 20,
-            },
-            "sp1": {"recursion": "plonk", "prover": "network", "verify": True},
-        }
+        return generate_shasta_post_data(
+            proposals,
+            proof_type=self.prove_type,
+            aggregate=aggregate,
+            api_version=self.proof_api_version,
+        )
 
     async def submit_to_raiko(
         self, proposal_id: int, l1_inclusion_block: int, l2_block_numbers: list[int], last_anchor_block_number: int
@@ -934,7 +1039,7 @@ class BatchMonitor:
             print(f"payload = {payload}")
 
             response = requests.post(
-                f"{self.raiko_rpc}/v3/proof/batch/shasta",
+                shasta_proof_endpoint(self.raiko_rpc, self.proof_api_version),
                 headers=headers,
                 json=payload,
                 timeout=10,
@@ -978,7 +1083,7 @@ class BatchMonitor:
             print(f"aggregate payload = {payload}")
 
             response = requests.post(
-                f"{self.raiko_rpc}/v3/proof/batch/shasta",
+                shasta_proof_endpoint(self.raiko_rpc, self.proof_api_version),
                 headers=headers,
                 json=payload,
                 timeout=10,
@@ -1018,7 +1123,7 @@ class BatchMonitor:
             }
             payload = self.generate_post_data([proposal_data], aggregate=False)
             response = requests.post(
-                f"{self.raiko_rpc}/v3/proof/batch/shasta",
+                shasta_proof_endpoint(self.raiko_rpc, self.proof_api_version),
                 headers=headers,
                 json=payload,
                 timeout=10,
@@ -1042,7 +1147,7 @@ class BatchMonitor:
             headers = {"x-api-key": "1", "Content-Type": "application/json"}
             payload = self.generate_post_data(proposals, aggregate=True)
             response = requests.post(
-                f"{self.raiko_rpc}/v3/proof/batch/shasta",
+                shasta_proof_endpoint(self.raiko_rpc, self.proof_api_version),
                 headers=headers,
                 json=payload,
                 timeout=10,
@@ -1112,6 +1217,7 @@ class BatchMonitor:
 
                 if response.data:
                     retry_count = 0  # reset retry count
+                    proof = extract_proof_from_response_data(response.data)
                     if response.data.get("status") == "registered":
                         self.logger.info(
                             f"Proposal {group.proposal_id} in L1 Block {l1_inclusion_block} registered"
@@ -1120,9 +1226,10 @@ class BatchMonitor:
                         self.logger.info(
                             f"Proposal {group.proposal_id} in L1 Block {l1_inclusion_block} in progress"
                         )
-                    elif response.data.get("proof"):
+                    elif is_completed_response_data(response.data):
+                        proof_suffix = f" with proof {proof}" if proof else ""
                         self.logger.info(
-                            f"Proposal {group.proposal_id} in L1 Block {l1_inclusion_block} completed with proof {response.data['proof']['proof']}"
+                            f"Proposal {group.proposal_id} in L1 Block {l1_inclusion_block} completed{proof_suffix}"
                         )
                         # If aggregate mode is enabled, add completed proposal to pending list
                         if self.aggregate > 0:
@@ -1159,8 +1266,9 @@ class BatchMonitor:
                 )
                 if response.message:
                     f.write(f"Message: {response.message}\n")
-                if response.data and response.data.get("proof"):
-                    f.write(f"Proof: {response.data['proof']['proof']}\n")
+                proof = extract_proof_from_response_data(response.data)
+                if proof:
+                    f.write(f"Proof: {proof}\n")
         finally:
             self.running_count -= 1
             self.logger.info(
@@ -1446,7 +1554,7 @@ class BatchMonitor:
             completed_requests = []
             for proposals in self.aggregate_requests:
                 response = await self.query_aggregate_status(proposals)
-                if response.data and response.data.get("proof"):
+                if is_completed_response_data(response.data):
                     proposal_ids = [p["proposal_id"] for p in proposals]
                     self.logger.info(
                         f"Aggregate request for proposals {proposal_ids} completed"
@@ -1470,6 +1578,7 @@ class BatchMonitor:
             "raiko_rpc": self.raiko_rpc,
             "l2_block_range": self.l2_block_range,
             "prove_type": self.prove_type,
+            "proof_api_version": self.proof_api_version,
             "block_running_ratio": self.block_running_ratio,
             "aggregate": self.aggregate,
         }
@@ -1617,6 +1726,13 @@ async def main():
         help="Aggregate mode: if > 0, collect n proposals and submit as aggregate request",
     )
 
+    parser.add_argument(
+        "--proof-api-version",
+        choices=sorted(SUPPORTED_SHASTA_API_VERSIONS),
+        default="v3",
+        help="Raiko Shasta proof API version to call; defaults to v3 for backward compatibility",
+    )
+
     args = parser.parse_args()
 
     monitor = BatchMonitor(
@@ -1634,6 +1750,7 @@ async def main():
         time_speed=args.time_speed,
         anchor_abi_file=args.anchor_abi_file,
         aggregate=args.aggregate,
+        proof_api_version=args.proof_api_version,
     )
 
     await monitor.run()
@@ -1647,5 +1764,6 @@ async def main():
 #   -g now specifies L2 block range instead of L1 block range
 #   -b (--anchor-abi-file) is optional but recommended for proper anchorV4 decoding
 #   -A (--aggregate): Aggregate mode, if > 0, collect n proposals and submit as aggregate request
+#   --proof-api-version: Raiko Shasta proof API version, v3 or v4
 if __name__ == "__main__":
     asyncio.run(main())

--- a/script/test_stress_shasta_proposal.py
+++ b/script/test_stress_shasta_proposal.py
@@ -1,0 +1,100 @@
+import unittest
+
+from stress_shasta_proposal import (
+    extract_proof_from_response_data,
+    generate_shasta_post_data,
+    get_contract_event_logs,
+    is_completed_response_data,
+    shasta_proof_endpoint,
+)
+
+
+class ShastaProofApiVersionTest(unittest.TestCase):
+    def test_v3_payload_and_endpoint_remain_unchanged(self):
+        proposal = {
+            "proposal_id": 42,
+            "l1_inclusion_block_number": 100,
+            "l2_block_numbers": [200, 201, 202],
+            "checkpoint": None,
+            "last_anchor_block_number": 199,
+        }
+
+        payload = generate_shasta_post_data(
+            [proposal],
+            proof_type="native",
+            aggregate=False,
+            api_version="v3",
+        )
+
+        self.assertEqual(
+            shasta_proof_endpoint("http://localhost:8080", "v3"),
+            "http://localhost:8080/v3/proof/batch/shasta",
+        )
+        self.assertEqual(payload["proposals"][0]["l2_block_numbers"], [200, 201, 202])
+        self.assertIn("blob_proof_type", payload)
+        self.assertIn("native", payload)
+
+    def test_v4_payload_uses_proposal_ranges(self):
+        proposal = {
+            "proposal_id": 42,
+            "l1_inclusion_block_number": 100,
+            "l2_block_numbers": [200, 201, 202],
+            "checkpoint": None,
+            "last_anchor_block_number": 199,
+        }
+
+        payload = generate_shasta_post_data(
+            [proposal],
+            proof_type="sgx",
+            aggregate=False,
+            api_version="v4",
+        )
+
+        self.assertEqual(
+            shasta_proof_endpoint("http://localhost:8080/", "v4"),
+            "http://localhost:8080/v4/proof/proposal",
+        )
+        self.assertEqual(payload["proof_type"], "sgx")
+        self.assertEqual(payload["proposals"][0]["l2_block_number_start"], 200)
+        self.assertEqual(payload["proposals"][0]["l2_block_number_end"], 202)
+        self.assertNotIn("l2_block_numbers", payload["proposals"][0])
+        self.assertNotIn("blob_proof_type", payload)
+        self.assertNotIn("native", payload)
+        self.assertNotIn("sgx", payload)
+
+    def test_extract_proof_accepts_v3_object_and_v4_string(self):
+        self.assertEqual(
+            extract_proof_from_response_data({"proof": {"proof": "0xabc"}}),
+            "0xabc",
+        )
+        self.assertEqual(
+            extract_proof_from_response_data({"proof": "0xdef"}),
+            "0xdef",
+        )
+
+    def test_completed_status_counts_as_done_when_native_proof_is_null(self):
+        self.assertTrue(is_completed_response_data({"status": "completed", "proof": None}))
+        self.assertTrue(is_completed_response_data({"proof": {"proof": "0xabc"}}))
+
+    def test_get_contract_event_logs_falls_back_to_web3_v6_keywords(self):
+        class DummyEvent:
+            def __init__(self):
+                self.calls = []
+
+            def get_logs(self, **kwargs):
+                self.calls.append(kwargs)
+                if "from_block" in kwargs:
+                    raise TypeError("unexpected keyword argument 'from_block'")
+                return ["log"]
+
+        event = DummyEvent()
+
+        self.assertEqual(get_contract_event_logs(event, 1, 2), ["log"])
+        self.assertEqual(
+            event.calls,
+            [{"from_block": 1, "to_block": 2}, {"fromBlock": 1, "toBlock": 2}],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add /v4/proof/proposal as a thin adapter over the existing v3 Shasta batch proof path
- convert v4 l2_block_number_start/end ranges into legacy l2_block_numbers
- map legacy v3 proof/status responses into the raiko2-style v4 response envelope
- add --proof-api-version v4 to script/stress_shasta_proposal.py while keeping v3 as the default path

## Regression
- mainnet v4 native regression completed for proposal 19716
- requested L2 seed range: 8407605,8407605
- resolved proposal range: L2 8407588..8407779, L1 inclusion 25477944, last_anchor_block_number 25477875
- request payload used /v4/proof/proposal shape with l2_block_number_start=8407588 and l2_block_number_end=8407779

## Tests
- python3 script/test_stress_shasta_proposal.py
- python3 -m py_compile script/stress_shasta_proposal.py script/test_stress_shasta_proposal.py
- cargo test -p raiko-host v4_proposal
- cargo check -p raiko-host
- cargo fmt --all -- --check
- git diff --check