### PR TITLE
ci(sgx): signed SGX release image build via Secret Manager + WIF

### DIFF
--- a/.github/workflows/release-sgx-image.yml
+++ b/.github/workflows/release-sgx-image.yml
@@ -1,0 +1,48 @@
+# .github/workflows/release-sgx-image.yml  (taikoxyz/raiko)
+# Builds & pushes the SIGNED SGX release image. The enclave signing key is
+# pulled from GCP Secret Manager at build time by script/publish-image.sh —
+# no human ever holds it, and it never lands in an image layer.
+name: Release - SGX signed image
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Image tag to build & push"
+        required: true
+      edmm:
+        description: "EDMM flag (1 = on)"
+        default: "1"
+
+permissions:
+  contents: read
+  id-token: write        # required for Workload Identity Federation
+
+jobs:
+  build-sign-push:
+    runs-on: [taiko-runner]         # SGX-capable runner (same as ci-sgx-docker)
+    timeout-minutes: 90
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+
+      - id: auth
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ vars.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ vars.GCP_ENCLAVE_SIGNER_SA }}
+
+      - uses: google-github-actions/setup-gcloud@v2
+
+      # (registry login step here — your existing release convention)
+
+      - name: Build, sign & push SGX image
+        env:
+          GCP_ENCLAVE_KEY_SECRET: ${{ vars.GCP_ENCLAVE_KEY_SECRET }}
+          GCP_ENCLAVE_KEY_PROJECT: ${{ vars.GCP_ENCLAVE_KEY_PROJECT }}
+          # GCP_ENCLAVE_KEY_VERSION: latest   # optional; latest == v2 today
+        run: |
+          # publish-image.sh prompts for proof type (0=tee/SGX, 1=zk); feed via stdin.
+          # args: $1 = EDMM flag, $2 = tag
+          echo "0" | ./script/publish-image.sh "${{ inputs.edmm }}" "${{ inputs.tag }}"

--- a/.github/workflows/release-sgx-image.yml
+++ b/.github/workflows/release-sgx-image.yml
@@ -35,7 +35,11 @@ jobs:
 
       - uses: google-github-actions/setup-gcloud@v2
 
-      # (registry login step here — your existing release convention)
+      # Auth Docker to the Artifact Registry host publish-image.sh pushes to
+      # (DOCKER_REPOSITORY=us-docker.pkg.dev/evmchain/images). Uses the same
+      # WIF credential from the auth step above — no registry secret needed.
+      - name: Configure Docker for Artifact Registry
+        run: gcloud auth configure-docker us-docker.pkg.dev --quiet
 
       - name: Build, sign & push SGX image
         env:
@@ -43,6 +47,7 @@ jobs:
           GCP_ENCLAVE_KEY_PROJECT: ${{ vars.GCP_ENCLAVE_KEY_PROJECT }}
           # GCP_ENCLAVE_KEY_VERSION: latest   # optional; latest == v2 today
         run: |
-          # publish-image.sh prompts for proof type (0=tee/SGX, 1=zk); feed via stdin.
-          # args: $1 = EDMM flag, $2 = tag
-          echo "0" | ./script/publish-image.sh "${{ inputs.edmm }}" "${{ inputs.tag }}"
+          # publish-image.sh is interactive: it prompts for proof type
+          # (0=tee/SGX, 1=zk) and then for a push confirmation (y/N).
+          # Feed both via stdin. args: $1 = EDMM flag, $2 = tag.
+          printf '0\ny\n' | ./script/publish-image.sh "${{ inputs.edmm }}" "${{ inputs.tag }}"

--- a/.github/workflows/release-sgx-image.yml
+++ b/.github/workflows/release-sgx-image.yml
@@ -2,16 +2,23 @@
 # Builds & pushes the SIGNED SGX release image. The enclave signing key is
 # pulled from GCP Secret Manager at build time by script/publish-image.sh —
 # no human ever holds it, and it never lands in an image layer.
+#
+# Trust model (see PR description): the signer identity is impersonable ONLY by
+# THIS workflow file running on refs/heads/main, via a dedicated WIF pool
+# (github-raiko-signer) whose provider is locked to repository == taikoxyz/raiko.
+# So it must be dispatched from the main branch after merge.
 name: Release - SGX signed image
 
 on:
   workflow_dispatch:
     inputs:
       tag:
-        description: "Image tag to build & push"
+        description: "Image tag to build & push (e.g. 1.2.3)"
         required: true
       edmm:
-        description: "EDMM flag (1 = on)"
+        description: "EDMM flag"
+        type: choice
+        options: ["1", "0"]
         default: "1"
 
 permissions:
@@ -21,19 +28,24 @@ permissions:
 jobs:
   build-sign-push:
     runs-on: [taiko-runner]         # SGX-capable runner (same as ci-sgx-docker)
+    # Gate on a protected environment — a repo admin must configure required
+    # reviewers + restrict deployment branches to main on this environment.
+    # The environment approval is defense-in-depth; the WIF ref-scoping above
+    # is the real cloud trust boundary.
+    environment: sgx-release-signing
     timeout-minutes: 90
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           submodules: true
 
       - id: auth
-        uses: google-github-actions/auth@v2
+        uses: google-github-actions/auth@c200f3691d83b41bf9bbd8638997a462592937ed # v2
         with:
           workload_identity_provider: ${{ vars.GCP_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ vars.GCP_ENCLAVE_SIGNER_SA }}
 
-      - uses: google-github-actions/setup-gcloud@v2
+      - uses: google-github-actions/setup-gcloud@e427ad8a34f8676edf47cf7d7925499adf3eb74f # v2
 
       # Auth Docker to the Artifact Registry host publish-image.sh pushes to
       # (DOCKER_REPOSITORY=us-docker.pkg.dev/evmchain/images). Uses the same
@@ -43,11 +55,19 @@ jobs:
 
       - name: Build, sign & push SGX image
         env:
+          # Pass dispatch inputs via env — NEVER interpolate ${{ inputs.* }}
+          # directly into a run: script (that is shell injection).
+          INPUT_EDMM: ${{ inputs.edmm }}
+          INPUT_TAG: ${{ inputs.tag }}
           GCP_ENCLAVE_KEY_SECRET: ${{ vars.GCP_ENCLAVE_KEY_SECRET }}
           GCP_ENCLAVE_KEY_PROJECT: ${{ vars.GCP_ENCLAVE_KEY_PROJECT }}
           # GCP_ENCLAVE_KEY_VERSION: latest   # optional; latest == v2 today
         run: |
+          set -euo pipefail
+          # Validate inputs before they reach the build script.
+          [[ "$INPUT_EDMM" =~ ^[01]$ ]] || { echo "Invalid EDMM value: $INPUT_EDMM" >&2; exit 1; }
+          [[ "$INPUT_TAG" =~ ^[A-Za-z0-9_][A-Za-z0-9_.-]{0,127}$ ]] || { echo "Invalid image tag: $INPUT_TAG" >&2; exit 1; }
           # publish-image.sh is interactive: it prompts for proof type
-          # (0=tee/SGX, 1=zk) and then for a push confirmation (y/N).
-          # Feed both via stdin. args: $1 = EDMM flag, $2 = tag.
-          printf '0\ny\n' | ./script/publish-image.sh "${{ inputs.edmm }}" "${{ inputs.tag }}"
+          # (0=tee/SGX, 1=zk) then a push confirmation (y/N). Feed both via stdin.
+          # args: $1 = EDMM flag, $2 = tag.
+          printf '0\ny\n' | ./script/publish-image.sh "$INPUT_EDMM" "$INPUT_TAG"


### PR DESCRIPTION
## What

Adds a `workflow_dispatch` release workflow that builds & pushes the **signed SGX release image**, pulling the enclave signing key from GCP Secret Manager at build time — so no engineer ever needs direct access to `raiko-enclave-key`.

## Why

Engineers don't (and shouldn't) have access to the GCE/Secret Manager secret `raiko-enclave-key` in the `evmchain` project. But `script/publish-image.sh` already knows how to fetch it itself: when `GCP_ENCLAVE_KEY_SECRET`/`GCP_ENCLAVE_KEY_PROJECT` are set it runs `gcloud secrets versions access --out-file <tmpfile>`, passes it to the build as a BuildKit `--secret id=enclave_key` (never baked into a layer), puts only the *public* key SHA256 in a build-arg, and deletes the tmpfile on exit.

So the only thing needed is for the **CI identity** to have `secretAccessor` on that one secret.

## GCP wiring (already provisioned, least-privilege)

- Dedicated GSA `raiko-enclave-signer@evmchain.iam.gserviceaccount.com`.
- `roles/secretmanager.secretAccessor` on **only** `raiko-enclave-key` (secret-level, not project-wide).
- `roles/artifactregistry.writer` on **only** the `images` repo (`us`) — for the image push.
- `roles/iam.workloadIdentityUser` scoped to **exactly this workflow file on `refs/heads/main`** — `principalSet://…/github-raiko-signer/attribute.job_workflow_ref/taikoxyz/raiko/.github/workflows/release-sgx-image.yml@refs/heads/main`. This lives in a **dedicated WIF pool** (`github-raiko-signer`) whose provider is locked to `assertion.repository == 'taikoxyz/raiko'` — deliberately **not** the shared `terraform-pool` that federates taiko-mono. No JSON keys.

The push target is Artifact Registry (`DOCKER_REPOSITORY=us-docker.pkg.dev/evmchain/images`, hardcoded in `publish-image.sh`), so the workflow authenticates Docker with `gcloud auth configure-docker us-docker.pkg.dev` using the same WIF credential — no registry secret needed. Both interactive prompts (proof type + push confirm) are fed via stdin, so it runs unattended.

## Repo config

These are set as **repo Actions variables** (non-secret):

| Variable | Value |
|---|---|
| `GCP_WORKLOAD_IDENTITY_PROVIDER` | `projects/790288402401/…/workloadIdentityPools/github-raiko-signer/providers/github` |
| `GCP_ENCLAVE_SIGNER_SA` | `raiko-enclave-signer@evmchain.iam.gserviceaccount.com` |
| `GCP_ENCLAVE_KEY_SECRET` | `raiko-enclave-key` |
| `GCP_ENCLAVE_KEY_PROJECT` | `evmchain` |

## Security hardening (from an adversarial review of this PR)

Applied in this branch / on the GCP side:

- **Shell-injection fix (was critical):** dispatch inputs are no longer interpolated into the `run:` script. They pass through `env:` and are regex-validated; `edmm` is a constrained `choice`.
- **WIF blast radius (was high):** signer trust re-scoped from repo-wide to *exactly this workflow file on `main`*, in a dedicated pool isolated from `terraform-pool`/taiko-mono (see above). **Consequence: dispatch only works from the `main` branch after merge** — it will not run from this feature branch by design.
- **Environment gate:** job now references `environment: sgx-release-signing`.
- **Supply chain:** all actions pinned to commit SHAs.

## Needs a repo admin / follow-up (can't do with push access)

- **Configure the `sgx-release-signing` environment:** required reviewers, disallow self-review, restrict deployment branch to `main`. The environment referenced here is inert until these rules are set.
- **Ephemeral signer runner:** `taiko-runner` is a persistent self-hosted pool; the MRSIGNER key lands on it as a tmpfile. Ideally sign on a single-use runner not shared with PR/CI workloads (or a non-exportable signing service).
- **Split signer vs. pusher identity:** today one GSA both reads the key and pushes to AR. A cleaner design builds+signs and pushes in two isolated jobs with separate identities, handing off by immutable digest. Left as a follow-up because it means restructuring `publish-image.sh`'s build+push flow.
- **`publish-image.sh` hardening (upstream tooling, not this PR):** install the key-cleanup `trap` immediately after `mktemp` and cover `HUP INT TERM`; drop global `set -x` for the key's lifetime.

Builds **tee/SGX** by default (stdin feeds `0`); flip to `1` for a zk variant. Runs on `[taiko-runner]` to match `ci-sgx-docker.yml`.
